### PR TITLE
Generate diff only if old_report exists

### DIFF
--- a/_plugins/rosindex_generator.rb
+++ b/_plugins/rosindex_generator.rb
@@ -1204,12 +1204,14 @@ class Indexer < Jekyll::Generator
     site.static_files << ReportFile.new(site, site.dest, "/", report_filename)
     File.open(site.config['report_filename'],'w') {|f| f.write(report_yaml) }
 
-    report_diff = @db.diff_report(old_report, new_report)
-    report_yaml = report_diff.to_yaml
-    report_filename = 'index_report_diff.yaml'
-    File.open(File.join(site.dest, report_filename),'w') {|f| f.write(report_yaml) }
-    site.static_files << ReportFile.new(site, site.dest, "/", report_filename)
-    File.open(site.config['report_diff_filename'],'w') {|f| f.write(report_yaml) }
+    if not old_report.empty?
+      report_diff = @db.diff_report(old_report, new_report)
+      report_yaml = report_diff.to_yaml
+      report_filename = 'index_report_diff.yaml'
+      File.open(File.join(site.dest, report_filename),'w') {|f| f.write(report_yaml) }
+      site.static_files << ReportFile.new(site, site.dest, "/", report_filename)
+      File.open(site.config['report_diff_filename'],'w') {|f| f.write(report_yaml) }
+    end
 
     # compute post-scrape details
     # TODO: check for missing deps or just leave them as nil?


### PR DESCRIPTION
This PR only generates a diff between the old report and new report if the old report exists. 4fe9cb057e5b03b48e32468824154743f5a504c1 makes code only read the old report if it exists, however with an empty `_caches` directory I get the following error running `rake build:devel`

```
/rosindex/_ruby_libs/rosindex.rb:194:in `block in report_adds': undefined method `each' for nil:NilClass (NoMethodError)
        from /rosindex/_ruby_libs/rosindex.rb:192:in `each'
        from /rosindex/_ruby_libs/rosindex.rb:192:in `report_adds'
        from /rosindex/_ruby_libs/rosindex.rb:185:in `diff_report'
        from /rosindex/_plugins/rosindex_generator.rb:1207:in `generate'
        from /var/lib/gems/2.3.0/gems/jekyll-3.8.3/lib/jekyll/site.rb:175:in `block in generate'
        from /var/lib/gems/2.3.0/gems/jekyll-3.8.3/lib/jekyll/site.rb:173:in `each'
        from /var/lib/gems/2.3.0/gems/jekyll-3.8.3/lib/jekyll/site.rb:173:in `generate'
        from /var/lib/gems/2.3.0/gems/jekyll-3.8.3/lib/jekyll/site.rb:70:in `process'
        from /var/lib/gems/2.3.0/gems/jekyll-3.8.3/lib/jekyll/command.rb:28:in `process_site'
        from /var/lib/gems/2.3.0/gems/jekyll-3.8.3/lib/jekyll/commands/build.rb:65:in `build'
        from /var/lib/gems/2.3.0/gems/jekyll-3.8.3/lib/jekyll/commands/build.rb:36:in `process'
        from /var/lib/gems/2.3.0/gems/jekyll-3.8.3/lib/jekyll/commands/build.rb:18:in `block (2 levels) in init_with_program'
        from /var/lib/gems/2.3.0/gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `block in execute'
        from /var/lib/gems/2.3.0/gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `each'
        from /var/lib/gems/2.3.0/gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `execute'
        from /var/lib/gems/2.3.0/gems/mercenary-0.3.6/lib/mercenary/program.rb:42:in `go'
        from /var/lib/gems/2.3.0/gems/mercenary-0.3.6/lib/mercenary.rb:19:in `program'
        from /var/lib/gems/2.3.0/gems/jekyll-3.8.3/exe/jekyll:15:in `<top (required)>'
        from /usr/local/bin/jekyll:23:in `load'
        from /usr/local/bin/jekyll:23:in `<main>'
rake aborted!
```
