### PR TITLE
Fix deprecation warning about 'gems:'

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -197,5 +197,5 @@ repos_per_page: 50
 # uncomment the following line for testing (limit the number of indexed repos)
 max_repos: 00
 
-gems:
+plugins:
   - jekyll-sitemap


### PR DESCRIPTION
This fixes a deprecation warning that appears when running `rake serve:deploy` 


```
Deprecation: The 'gems' configuration option has been renamed to 'plugins'. Please update your config file accordingly.
```