### PR TITLE
Deploy to GitHub pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,13 @@ and uses client-side javascript for quick searching and visualization.
 
 ### Pre-Requisites
 
-#### Basic Ubuntu 12.04 Deps
+#### Basic Ubuntu 16.04 Deps
 
 ```
+echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list
+apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
 sudo apt-get update
-sudo apt-get install curl git git-svn mercurial nodejs pandoc
+sudo apt-get install curl git git-svn mercurial nodejs pandoc python3-vcs
 ```
 
 #### Ruby 2.2 via RVM
@@ -54,39 +56,30 @@ gem install bundler
 #### Clone Source and Install Gems
 
 ```
-git clone git@github.com:rosindex/rosindex --recursive
+git clone git@github.com:ros2/rosindex.git --recursive
 cd rosindex.github.io
 bundle install
 ```
 
-### Get resources
-
-Needed resources are the rosdistro to index and the rosdep keys as well as known forks.
-TODO document vcs
-```
-vcs import --input resources.repos ..
-```
-
-### Create necessary temporary files
+### Clone repos that are part of rosdistro and build the index
 
 ```
-mkdir -p ../cache/checkout
-mkdir ../deploy
+make build
 ```
 
-### Build the Devel (Tiny) Version
+### Serve the devel (tiny) version locally
 
 ```
-rake build:devel
+make serve-devel
 ```
 
-### Build the Deploy (Full) Version
+### Serve the full version locally
 
 **Note:** This requires a minimum of 30GB of
-free space for the `_checkout` directory.
+free space for the `checkout` directory.
 
 ```
-rake build:devel
+make serve
 ```
 
 ### Skipping Parts of the Build
@@ -116,12 +109,8 @@ skip_search_index: false
 
 ## Deployment
 
-Deployment is done by simply pushing the generated site to GitHub:
+Deployment is done by calling the following make command:
 
 ```
-cd _deploy
-git add .
-git commit -a --amend
-git push -f origin master
+make deploy
 ```
-

--- a/makefile
+++ b/makefile
@@ -11,14 +11,18 @@ html: build deploy
 # Clone a bunch of other repos part of the rosdistro and build the index.
 build:
 	mkdir -p $(deploy_dir)/cache
+	mkdir -p $(workdir)/cache/checkout
+	vcs import --input resources.repos $(workdir)
 	bundle exec jekyll build --verbose --trace --config=$(config_file)
 
 # deploy assumes download-previous and build were run already
 deploy:
-	cd $(deploy_dir) && git add --all
-	cd $(deploy_dir) && git status
-	cd $(deploy_dir) && git commit -m "make deploy by `whoami` on `date`"
-	cd $(deploy_dir) && git push --verbose
+	# TODO(apojomovsky): re-enable deployment once the deploy URL is updated in
+	# https://github.com/ros2/rosindex/blob/clear_submodules/resources.repos#L16
+	#cd $(deploy_dir) && git add --all
+	#cd $(deploy_dir) && git status
+	#cd $(deploy_dir) && git commit -m "make deploy by `whoami` on `date`"
+	#cd $(deploy_dir) && git push --verbose
 
 serve:
 	bundle exec jekyll serve --host 0.0.0.0 --trace -d $(deploy_dir) --config=$(config_file) --skip-initial-build

--- a/makefile
+++ b/makefile
@@ -3,6 +3,7 @@ devel_config_file=_config_devel.yml
 
 workdir=..
 deploy_dir=$(workdir)/deploy
+cache_dir=$(workdir)/deploy_cache
 checkout_dir=$(workdir)/checkout
 
 # This target is invoked by a doc_independent job on the ROS buildfarm.
@@ -10,19 +11,18 @@ html: build deploy
 
 # Clone a bunch of other repos part of the rosdistro and build the index.
 build:
-	mkdir -p $(deploy_dir)/cache
-	mkdir -p $(workdir)/cache/checkout
+	mkdir -p $(checkout_dir)
+	mkdir -p $(deploy_dir)
+	mkdir -p $(cache_dir)
 	vcs import --input resources.repos $(workdir)
 	bundle exec jekyll build --verbose --trace --config=$(config_file)
 
 # deploy assumes download-previous and build were run already
 deploy:
-	# TODO(apojomovsky): re-enable deployment once the deploy URL is updated in
-	# https://github.com/ros2/rosindex/blob/clear_submodules/resources.repos#L16
-	#cd $(deploy_dir) && git add --all
-	#cd $(deploy_dir) && git status
-	#cd $(deploy_dir) && git commit -m "make deploy by `whoami` on `date`"
-	#cd $(deploy_dir) && git push --verbose
+	cd $(deploy_dir) && git add --all
+	cd $(deploy_dir) && git status
+	cd $(deploy_dir) && git commit -m "make deploy by `whoami` on `date`"
+	cd $(deploy_dir) && git push --verbose
 
 serve:
 	bundle exec jekyll serve --host 0.0.0.0 --trace -d $(deploy_dir) --config=$(config_file) --skip-initial-build
@@ -31,5 +31,6 @@ serve-devel:
 	bundle exec jekyll serve --host 0.0.0.0 --no-watch -d $(deploy_dir) --trace --config=$(config_file),$(devel_config_file) --skip-initial-build
 
 clean:
-	rm -rf $(deploy_dir)
 	rm -rf $(checkout_dir)
+	rm -rf $(deploy_dir)
+	rm -rf $(cache_dir)

--- a/makefile
+++ b/makefile
@@ -1,0 +1,31 @@
+config_file=_config.yml
+devel_config_file=_config_devel.yml
+
+workdir=..
+deploy_dir=$(workdir)/deploy
+checkout_dir=$(workdir)/checkout
+
+# This target is invoked by a doc_independent job on the ROS buildfarm.
+html: build deploy
+
+# Clone a bunch of other repos part of the rosdistro and build the index.
+build:
+	mkdir -p $(deploy_dir)/cache
+	bundle exec jekyll build --verbose --trace --config=$(config_file)
+
+# deploy assumes download-previous and build were run already
+deploy:
+	cd $(deploy_dir) && git add --all
+	cd $(deploy_dir) && git status
+	cd $(deploy_dir) && git commit -m "make deploy by `whoami` on `date`"
+	cd $(deploy_dir) && git push --verbose
+
+serve:
+	bundle exec jekyll serve --host 0.0.0.0 --trace -d $(deploy_dir) --config=$(config_file) --skip-initial-build
+
+serve-devel:
+	bundle exec jekyll serve --host 0.0.0.0 --no-watch -d $(deploy_dir) --trace --config=$(config_file),$(devel_config_file) --skip-initial-build
+
+clean:
+	rm -rf $(deploy_dir)
+	rm -rf $(checkout_dir)

--- a/resources.repos
+++ b/resources.repos
@@ -14,4 +14,4 @@ repositories:
   deploy:
     type: git
     url: git@github.com:ros-infrastructure/index.ros.org.git
-    version: master
+    version: gh-pages


### PR DESCRIPTION
FYI @tfoote here is the makefile I started today. It is meant to run in a [doc_independent job like @dirk-thomas recommended](https://github.com/ros-infrastructure/ros_buildfarm/issues/568#issuecomment-413025662).

The makefile downloads the cache, builds the index, and then pushes the updated cache and index files to a staging repo. Instead of submodules the makefile invokes git commands directly, though it's missing a solution for `rosdep` and `rosdistro`.

connects to ros2/rosindex#1

