### PR TITLE
Keeps cache in its rightful place

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,6 +8,7 @@ url: "https://ros-infrastructure.github.io/index.ros.org/" # the base hostname &
 #twitter_username: jekyllrb
 github_username:  rosindex
 destination: ../deploy
+keep_files: [cache, .git]
 
 # Build settings
 markdown: redcarpet
@@ -31,12 +32,12 @@ redcarpet:
 #highlighter: pygments
 
 # If true, this begins with an existing db
-use_db_cache: false
-db_cache_filename: ../deploy_cache/_deploy_cache.db
-report_filename: ../deploy_cache/_deploy_index_report.yaml
-report_diff_filename: ../deploy_cache/_deploy_index_report_diff.yaml
-debbuild_release_path: ../deploy_cache/debbuild_releases
-wiki_title_index_filename: ../deploy_cache/ros_org_wiki_title_index.txt
+use_db_cache: true
+db_cache_filename: ../deploy/cache/_deploy_cache.db
+report_filename: ../deploy/cache/_deploy_index_report.yaml
+report_diff_filename: ../deploy/cache/_deploy_index_report_diff.yaml
+debbuild_release_path: ../deploy/cache/debbuild_releases
+wiki_title_index_filename: ../deploy/cache/ros_org_wiki_title_index.txt
 
 # If true, this skips finding repos based on the repo sources
 skip_discover: false

--- a/_plugins/rosindex_generator.rb
+++ b/_plugins/rosindex_generator.rb
@@ -936,7 +936,7 @@ class Indexer < Jekyll::Generator
               if @all_repos.key?(repo.id)
                 repo = @all_repos[repo.id]
               else
-                puts " -- Adding repo " << repo.name << " instance: " << repo.id << " from uri: " << repo.uri.to_s << " with version: " <<source_version
+                puts " -- Adding repo " << repo.name << " instance: " << repo.id << " from uri: " << repo.uri.to_s << " with version: " << source_version
                 # store this repo in the unique index
                 @all_repos[repo.id] = repo
               end
@@ -1175,14 +1175,14 @@ class Indexer < Jekyll::Generator
       end
     end
 
-
     if site.config['use_db_cache']
       # backup the current db if it exists
       if File.exist?(@db_cache_filename) then FileUtils.mv(@db_cache_filename, @db_cache_filename+'.bak') end
       # save scraped data into the cache db
+      db_cache_dirname = File.dirname(@db_cache_filename)
+      Dir.mkdir(db_cache_dirname) unless File.directory?(db_cache_dirname)
       File.open(@db_cache_filename, 'w') {|f| f.write(Marshal.dump(@db)) }
     end
-
 
     puts "Generating update report...".blue
 
@@ -1204,6 +1204,8 @@ class Indexer < Jekyll::Generator
 
     File.open(File.join(site.dest, report_filename),'w+') {|f| f.write(report_yaml) }
     site.static_files << ReportFile.new(site, site.dest, "/", report_filename)
+    report_dirname = File.dirname(site.config['report_filename'])
+    Dir.mkdir(report_dirname) unless File.directory?(report_dirname)
     File.open(site.config['report_filename'],'w') {|f| f.write(report_yaml) }
 
     if not old_report.empty?
@@ -1212,6 +1214,8 @@ class Indexer < Jekyll::Generator
       report_filename = 'index_report_diff.yaml'
       File.open(File.join(site.dest, report_filename),'w') {|f| f.write(report_yaml) }
       site.static_files << ReportFile.new(site, site.dest, "/", report_filename)
+      report_diff_dirname = File.dirname(site.config['report_diff_filename'])
+      Dir.mkdir(report_diff_dirname) unless File.directory?(report_diff_dirname)
       File.open(site.config['report_diff_filename'],'w') {|f| f.write(report_yaml) }
     end
 

--- a/makefile
+++ b/makefile
@@ -3,7 +3,6 @@ devel_config_file=_config_devel.yml
 
 workdir=..
 deploy_dir=$(workdir)/deploy
-cache_dir=$(workdir)/deploy_cache
 checkout_dir=$(workdir)/checkout
 
 # This target is invoked by a doc_independent job on the ROS buildfarm.
@@ -13,8 +12,7 @@ html: build deploy
 build:
 	mkdir -p $(checkout_dir)
 	mkdir -p $(deploy_dir)
-	mkdir -p $(cache_dir)
-	vcs import --input resources.repos $(workdir)
+	vcs import --input resources.repos --force $(workdir)
 	bundle exec jekyll build --verbose --trace --config=$(config_file)
 
 # deploy assumes download-previous and build were run already
@@ -28,9 +26,8 @@ serve:
 	bundle exec jekyll serve --host 0.0.0.0 --trace -d $(deploy_dir) --config=$(config_file) --skip-initial-build
 
 serve-devel:
-	bundle exec jekyll serve --host 0.0.0.0 --no-watch -d $(deploy_dir) --trace --config=$(config_file),$(devel_config_file) --skip-initial-build
+	bundle exec jekyll serve --host 0.0.0.0 --watch -d $(deploy_dir) --trace --config=$(config_file),$(devel_config_file) --skip-initial-build
 
 clean:
-	rm -rf $(checkout_dir)
 	rm -rf $(deploy_dir)
-	rm -rf $(cache_dir)
+	rm -rf $(checkout_dir)


### PR DESCRIPTION
Closes #10. This pull request moves the cache directory back inside the site, prevents Jekyll from nuking it on build (same as the .git directory) and delegates creation to the rosindex generator plugin (if necessary).