### PR TITLE
Add the ability to display explicitly given readme files

### DIFF
--- a/_includes/package_body.html
+++ b/_includes/package_body.html
@@ -148,25 +148,35 @@ Assumes distro and package are defined
         </div>
       </div>
     </div>
-    <div class="row">
-      <div class="col-xs-12">
-        <div class="panel panel-default">
-          <div class="panel-heading"><span class="glyphicon glyphicon-file"></span> README</div>
-          <div class="panel-body">
-            {% if package.data.readme_rendered %}
-              {{ package.data.readme_rendered }}
+    {% if package.data.readmes_rendered %}
+      {% for readme_rendered in package.data.readmes_rendered %}
+        <div class="row">
+          <div class="col-xs-12">
+            <div class="panel panel-default">
+              <div class="panel-heading"><span class="glyphicon glyphicon-file"></span> README </div>
+              <div class="panel-body">
+                    {{ readme_rendered }}
+              </div>
+            </div>
+          </div>
+        </div>
+      {% endfor %}
+    {% else %}
+      <div class="row">
+        <div class="col-xs-12">
+          <div class="panel panel-default">
+            <div class="panel-heading"><span class="glyphicon glyphicon-file"></span> README </div>
+            <div class="panel-body">
+            <em>No README found.</em>
+            {% if package.snapshot.data.readme_rendered %} <em><a href="{{site.baseurl}}/r/{{package.repo.name}}/{{package.repo.id}}/#{{distro}}">See repository README.</a></em>
             {% else %}
-              <em>No README found.</em>
-              {% if package.snapshot.data.readme_rendered %}
-                <em><a href="{{site.baseurl}}/r/{{package.repo.name}}/{{package.repo.id}}/#{{distro}}">See repository README.</a></em>
-              {% else %}
-                <em>No README in repository either.</em>
-              {% endif %}
+              <em>No README in repository either.</em>
             {% endif %}
+            </div>
           </div>
         </div>
       </div>
-    </div>
+    {% endif %}
     <div class="row">
       <div class="col-xs-12">
         <div class="panel panel-default">


### PR DESCRIPTION
Fixes #11 
This enables us to explicitly define the path to different README files like the following example:
```
  <export>
    <build_type>ament_cmake</build_type>
    <rosindex>
      <readme>doc/README.md</readme>
      <readme>doc/SECOND_README.md</readme>
    </rosindex>
  </export>
```

which will be displayed similarly to the image below:
![screenshot from 2018-09-11 18-06-31](https://user-images.githubusercontent.com/5348967/45388152-88658a80-b5ee-11e8-9c4c-5f7543ebc4dd.png)
