### PR TITLE
Remove reference to undefined variable in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,6 @@ html: build deploy
 build:
 	mkdir -p $(checkout_dir)
 	mkdir -p $(deploy_dir)
-	mkdir -p $(cache_dir)
 	vcs import --input $(data_dir)/repos/resources.yml --force $(workdir)
 	mkdir -p $(docs_dir)
 	vcs import --input $(data_dir)/repos/docs.yml $(docs_dir)


### PR DESCRIPTION
Removes an unwanted reference to the recently removed `cache_dir` variable.