### PR TITLE
Do not render disabled content

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -25,12 +25,13 @@
                     <li><a href="{{site.baseurl}}/packages/page/1/time/">Package List</a></li>
                     <li><a href="{{site.baseurl}}/repos/page/1/time/">Repository List</a></li>
 
-                    <li class="divider"></li>
+                    <li class="hidden" class="divider"></li>
 
-                    <li class="disabled"><a href="/srvs/">Nodes</a></li>
-                    <li class="disabled"><a href="/msgs/">Messages</a></li>
-                    <li class="disabled"><a href="/srvs/">Services</a></li>
-                    <li class="disabled"><a href="/srvs/">Plugins</a></li>
+
+                    <li class="hidden"><a href="/srvs/">Nodes</a></li>
+                    <li class="hidden"><a href="/msgs/">Messages</a></li>
+                    <li class="hidden"><a href="/srvs/">Services</a></li>
+                    <li class="hidden"><a href="/srvs/">Plugins</a></li>
 
                     <li class="divider"></li>
 
@@ -50,11 +51,11 @@
                       </a>
                     </li>
                     {% endfor %}
-                    <li class="divider"></li>
+                    <li class="hidden" class="divider"></li>
 
-                    <li class="disabled"><a href="{{site.baseurl}}/doc/tutorials">Tutorials</a></li>
-                    <li class="disabled"><a href="{{site.baseurl}}/doc/readmes">Readmes</a></li>
-                    <li class="disabled"><a href="{{site.baseurl}}/doc/apis">APIs</a></li>
+                    <li class="hidden"><a href="{{site.baseurl}}/doc/tutorials">Tutorials</a></li>
+                    <li class="hidden"><a href="{{site.baseurl}}/doc/readmes">Readmes</a></li>
+                    <li class="hidden"><a href="{{site.baseurl}}/doc/apis">APIs</a></li>
                   </ul>
                 </li>
 


### PR DESCRIPTION
Fixes #26 
Makes currently disabled items to not be shown within the `INDEX` and `DOC` drop-down menus.

<img src="https://user-images.githubusercontent.com/5348967/45559696-86cbda80-b819-11e8-8edf-33bbff91b1c1.png" width="300"> <img src="https://user-images.githubusercontent.com/5348967/45559697-86cbda80-b819-11e8-888d-023a653e9e60.png" width="300">