### PR TITLE
Fixes Docker volume mount loop

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -78,6 +78,7 @@ exclude:
   - Gemfile.lock
   - README.md
   - Makefile
+  - docker
 
 rosdep_path: ../rosdep
 rosdistro_path: ../rosdistro

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -18,7 +18,7 @@ fi
 docker run\
   --env SSH_AUTH_SOCK=/ssh-agent\
   -v $SSH_AUTH_SOCK:/ssh-agent\
-  -v "$SCRIPT_DIR/workdir:/workdir:rw"\
+  -v "$SCRIPT_DIR/../../workdir:/workdir:rw"\
   -v "$SCRIPT_DIR/..:/workdir/rosindex:rw"\
   --net=host\
   -p 4000:4000\


### PR DESCRIPTION
Precisely what the title says. Also excludes `docker/` dir from Jekyll's crawling path.