### PR TITLE
Include readme's filename with link to file in repo

### DIFF
--- a/_includes/package_body.html
+++ b/_includes/package_body.html
@@ -148,7 +148,7 @@ Assumes distro and package are defined
         </div>
       </div>
     </div>
-    {% if package.data.readmes %}
+    {% unless package.data.readmes == empty %}
       {% for readme in package.data.readmes %}
         <div class="row">
           <div class="col-xs-12">
@@ -176,7 +176,7 @@ Assumes distro and package are defined
           </div>
         </div>
       </div>
-    {% endif %}
+    {% endunless %}
     <div class="row">
       <div class="col-xs-12">
         <div class="panel panel-default">

--- a/_includes/package_body.html
+++ b/_includes/package_body.html
@@ -148,14 +148,20 @@ Assumes distro and package are defined
         </div>
       </div>
     </div>
-    {% if package.data.readmes_rendered %}
-      {% for readme_rendered in package.data.readmes_rendered %}
+    {% if package.data.readmes %}
+      {% for readme in package.data.readmes %}
         <div class="row">
           <div class="col-xs-12">
             <div class="panel panel-default">
-              <div class="panel-heading"><span class="glyphicon glyphicon-file"></span> README </div>
+              <div class="panel-heading"><span class="glyphicon glyphicon-file"></span>
+                {% if readme.filename.empty? %}
+                  <a>README</a>
+                {% else %}
+                  <a href="{{readme.browse_uri}}"> {{ readme.filename }}</a>
+                {% endif %}
+              </div>
               <div class="panel-body">
-                    {{ readme_rendered }}
+                    {{ readme.readme_rendered }}
               </div>
             </div>
           </div>

--- a/_includes/package_body.html
+++ b/_includes/package_body.html
@@ -153,13 +153,7 @@ Assumes distro and package are defined
         <div class="row">
           <div class="col-xs-12">
             <div class="panel panel-default">
-              <div class="panel-heading"><span class="glyphicon glyphicon-file"></span>
-                {% if readme.filename.empty? %}
-                  <a>README</a>
-                {% else %}
-                  <a href="{{readme.browse_uri}}"> {{ readme.filename }}</a>
-                {% endif %}
-              </div>
+              <div class="panel-heading"><span class="glyphicon glyphicon-file"></span><a href="{{readme.browse_uri}}">{{ readme.relpath }}</a></div>
               <div class="panel-body">
                     {{ readme.readme_rendered }}
               </div>

--- a/_includes/package_pager.html
+++ b/_includes/package_pager.html
@@ -1,7 +1,7 @@
 
 {% if page.page_index %}
 <div class="row text-center">
-y    <ul class="pagination pagination-sm">
+    <ul class="pagination pagination-sm">
       <li class="{% if page.page_index == 1 %}disabled{% endif %}">
     <a href="{% if page.page_index == 1 %}#{% else %}{{site.baseurl}}/{{page.pager.base}}/page/{{ page.prev_page }}{{page.pager.post_ns}}{% endif %}">&laquo;</a>
       </li>


### PR DESCRIPTION
Fixes #22
- Makes the filename to be shown as the panel title with a link to the browse URI of the file.
- Extends this behavior to work not only with explicitly defined readme files but with automatically found ones as well.
Example for multi-readme package, explicitly defined in `package.xml`:
<img src="https://user-images.githubusercontent.com/5348967/45638713-60f63e00-ba84-11e8-803b-de6f0bc5d535.png" height="300">

Example for automatically discovered README file:
<img src="https://user-images.githubusercontent.com/5348967/45638712-60f63e00-ba84-11e8-8f5a-0bdc1c1aac21.png" height="300">

