### PR TITLE
Fixes ReST to Markdown conversion issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ build:
 	mkdir -p $(deploy_dir)
 	vcs import --input $(data_dir)/repos/resources.yml --force $(workdir)
 	mkdir -p $(docs_dir)
-	vcs import --input $(data_dir)/repos/docs.yml $(docs_dir)
+	vcs import --input $(data_dir)/repos/docs.yml --force $(docs_dir)
 	bundle exec jekyll build --verbose --trace --config=$(config_file)
 
 # deploy assumes download-previous and build were run already


### PR DESCRIPTION
Connected to #40. This pull request:

- Fixes bad ReST files URL replacement.
- Prevents jekyll watch loop upon site regeneration.
- Forces repository pulls.

Solution is still partial. ReST files that are dropped upstream may persist locally as in their Markdown form. 

This will be solved in #24.