### PR TITLE
Support Edit On Github button for documentation pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -21,7 +21,7 @@ defaults:
     scope:
       path: "doc"
     values:
-      layout: page
+      layout: doc
 
 # OLD from jekyll 2.x
 #highlighter: pygments

--- a/_data/remotes.yml
+++ b/_data/remotes.yml
@@ -17,17 +17,7 @@ repositories:
     url: git@github.com:ros-infrastructure/index.ros.org.git
     version: gh-pages
 # List of all non-package specific documentation repositories.
-# The VCS file format has been extended to include, on a
-# per repository basis, the following extra fields:
-#
-# - 'short_description': A description to be used to refer
-#                        to the content of the repository
-#                        as a whole, e.g. ROS Install
-#                        Instructions.
-#
-# These extra fields will be ignored by VCS upon repo importation.
   ros2_overview:
     type: git
     url: git@github.com:ros2/ros2_documentation.git
-    edit_url: https://github.com/ros2/ros2_documentation/edit/master
     version: master

--- a/_data/remotes.yml
+++ b/_data/remotes.yml
@@ -29,5 +29,5 @@ repositories:
   ros2_overview:
     type: git
     url: git@github.com:ros2/ros2_documentation.git
-    short_description: "ROS2 Overview"
+    edit_url: https://github.com/ros2/ros2_documentation/edit/master
     version: master

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -44,12 +44,12 @@
                     Doc <span class="caret"></span>
                   </button>
                   <ul class="dropdown-menu" role="menu" aria-labelledby="dLabel">
-                    {% for repo_name in site.documentation_repos%}
-                      {% for repo in site.data.remotes.repositories %}
-                        {% if repo[0] == repo_name %}
-                          <li><a href="{{site.baseurl}}/doc/{{ repo[0] }}">{{ repo[1].short_description }}</a></li>
-                        {% endif %}
-                      {% endfor %}
+                    {% for repo in site.docs_repos %}
+                    <li>
+                      <a href="{{site.baseurl}}/doc/{{ repo.name }}">
+                        {{ repo.description }}
+                      </a>
+                    </li>
                     {% endfor %}
                     <li class="hidden" class="divider"></li>
 

--- a/_layouts/doc.html
+++ b/_layouts/doc.html
@@ -1,0 +1,38 @@
+---
+layout: default
+---
+
+<div class="container-fluid" style="margin-top:20px">
+  <div class="container-fluid">
+    <div class="row">
+      <ol class="breadcrumb">
+        <li><a href="{{site.baseurl}}/">Home</a></li>
+        {% for bc in page.breadcrumbs %}
+        <li><a href="{{site.baseurl}}/{{bc}}">{{bc}}</a></li>
+        {% endfor %}
+        <li class="active">{{ page.title }}</li>
+      </ol>
+      {% if page.edit_url %}
+      <a type="button" href="{{ page.edit_url }}" class="btn btn-success pull-right">
+        Edit on Github
+      </a>
+      {% endif %}
+    </div>
+    <div class="row">
+      <div class="col-md-10">  
+        {{ content }}
+      </div>
+    </div>
+  </div>
+</div>
+
+<script type="text/javascript">
+$(document).ready(
+    function() {
+      $('#toc').toc({
+        title: '',
+        listType: 'ul',
+        showSpeed: 0,
+        headers: 'h2, h3' });
+});
+</script>

--- a/_plugins/editable_docs.rb
+++ b/_plugins/editable_docs.rb
@@ -1,0 +1,21 @@
+Jekyll::Hooks.register :site, :pre_render do |site, payload|
+  repositories = site.data["remotes"]["repositories"]
+  site.pages.each do |page|
+    page_path = page.path
+    if page.data.key?("origin_path")
+      page_path = page.data["origin_path"]
+    end
+    next unless page_path.start_with?("doc")
+    repo_name, repo_data = repositories.find do |name, data|
+      page_path.start_with? (File.join("doc", name))
+    end
+    next if repo_name.nil? or repo_data.nil?
+    next unless repo_data.key?("edit_url")
+    page_relative_url = page_path.sub(File.join("doc", repo_name), "")
+    # Path joins won't look past a potential trailing slash (i.e.
+    # won't care about one of the fragments being a partial URL).
+    page.data["edit_url"] = File.join(
+      repo_data["edit_url"], page_relative_url
+    )
+  end
+end

--- a/_plugins/editable_docs.rb
+++ b/_plugins/editable_docs.rb
@@ -18,38 +18,26 @@ Jekyll::Hooks.register :site, :pre_render do |site, payload|
 end
 
 def generate_edit_url(repo_data, page_relative_url)
-  https = repo_data['url'].include? "https"
-  github = repo_data['url'].include? "github.com"
-  bitbucket = repo_data['url'].include? "bitbucket.org"
-
-  unless github or bitbucket
+  is_https = repo_data['url'].include? "https"
+  is_github = repo_data['url'].include? "github.com"
+  is_bitbucket = repo_data['url'].include? "bitbucket.org"
+  unless is_github or is_bitbucket
     raise ValueError("Cannot generate edition URL. Unknown organization for repository: #{repo_data['url']}")
   end
-  
-  if https
+  if is_https
     uri = URI(repo_data['url'])
+    host = uri.host
     organization, repo = uri.path.split("/").reject { |c| c.empty? }
-    if repo.end_with? ".git" then repo.chomp!(".git") end
-    if github
-      edit_url = "https://#{uri.host}/#{organization}/#{repo}/edit/#{repo_data['version']}"
-      return File.join(edit_url, page_relative_url)
-    elsif bitbucket
-      edit_url = "https://#{uri.host}/#{organization}/#{repo}/src/#{repo_data['version']}"
-      return File.join(edit_url, page_relative_url) + "?mode=edit&spa=0&at=#{repo_data['version']}&fileviewer=file-view-default"
-    end
   else # ssh
-    if github
-      host = repo_data['url'].split("@")[1].split(":")[0]
-      organization, repo = repo_data['url'].split("@")[1].split(":")[1].split("/")
-      if repo.end_with? ".git" then repo.chomp!(".git") end
-      edit_url = "https://#{host}/#{organization}/#{repo}/edit/#{repo_data['version']}"
-      return File.join(edit_url, page_relative_url)
-    elsif bitbucket
-      host = repo_data['url'].split("@")[1].split(":")[0]
-      organization, repo = repo_data['url'].split("@")[1].split(":")[1].split("/")
-      if repo.end_with? ".git" then repo.chomp!(".git") end
-      edit_url = "https://#{host}/#{organization}/#{repo}/src/#{repo_data['version']}"
-      return File.join(edit_url, page_relative_url) + "?mode=edit&spa=0&at=#{repo_data['version']}&fileviewer=file-view-default"
-    end
+    host, path = repo_data['url'].split("@")[1].split(":")
+    organization, repo = path.split("/")
+  end
+  repo.chomp!(".git") if repo.end_with? ".git"
+  if is_github
+    edit_url = "https://#{host}/#{organization}/#{repo}/edit/#{repo_data['version']}"
+    return File.join(edit_url, page_relative_url)
+  elsif is_bitbucket
+    edit_url = "https://#{host}/#{organization}/#{repo}/src/#{repo_data['version']}"
+    return File.join(edit_url, page_relative_url) + "?mode=edit&spa=0&at=#{repo_data['version']}&fileviewer=file-view-default"
   end
 end

--- a/_plugins/pulling_docs.rb
+++ b/_plugins/pulling_docs.rb
@@ -1,18 +1,17 @@
 # Copy the specified documentation repos into the
 # jekyll-tracked "doc" directory.
-
 require 'fileutils'
 
 Jekyll::Hooks.register :site, :after_init do |site|
-    site.config['documentation_repos'].each do |repo_dir|
-        origin = File.join(site.source, "_remotes", repo_dir)
-        dest = File.join(site.source, "doc") 
-        to_delete = File.join(site.source, repo_dir) 
-        if File.directory?(to_delete)
-            FileUtils.rm_r(to_delete)
+    site.config['docs_repos'].each do |repo|
+        src = File.join(site.source, "_remotes", repo["name"])
+        dest_dir = File.join(site.source, "doc")
+        dest = File.join(dest_dir, repo["name"])
+        if File.directory?(dest)
+          FileUtils.rm_r(dest)
         end
-        if File.directory?(origin)
-            FileUtils.cp_r(origin, dest)
+        if File.directory?(src)
+            FileUtils.cp_r(src, dest_dir)
         else
             raise IOError.new("Unable to copy from #{origin}, the directory doesn't exist.")
         end

--- a/_plugins/rst_as_markdown.rb
+++ b/_plugins/rst_as_markdown.rb
@@ -31,7 +31,12 @@ class RstAsMarkdown < Jekyll::Generator
         new_file = Jekyll::StaticFile.new(site, base, dir, new_name)
         next if File.exists?(new_file.path) &&
                 File.mtime(new_file.path) >= File.mtime(file.path)
-        File.write(new_file.path, rst_to_md(File.read(file.path)))
+        File.open(new_file.path, "w") do |f|
+          f.puts "---"
+          f.puts "origin_path: #{file.relative_path[1..-1]}"
+          f.puts "---"
+          f.write rst_to_md(File.read(file.path))
+        end
         new_file
       end
       replace_rst_links!(site, site.static_files)
@@ -39,6 +44,7 @@ class RstAsMarkdown < Jekyll::Generator
     replace_rst_files!(site.pages) do |page, base, dir, name|
       new_name = name.rpartition('.').first + '.md'
       new_page = Jekyll::Page.new(base, dir, new_name)
+      new_page.data["origin_path"] = page.path
       next if File.exists?(new_page.path) &&
               File.mtime(new_page.path) >= File.mtime(page.path)
       File.write(new_page.path, rst_to_md(File.read(page.path)))

--- a/index.yml
+++ b/index.yml
@@ -15,6 +15,8 @@ rosdistro_path: _remotes/rosdistro
 repos_path: _remotes/rosforks/repos
 attic_file: _remotes/rosforks/attic.yaml
 
-# Indicates which of the repositories tracked in remotes.yml correspond to documentation repos.
-documentation_repos:
-  - ros2_overview
+# Indicates which of the repositories tracked in remotes.yml
+# correspond to documentation repos.
+docs_repos:
+  - name: ros2_overview
+    description: "ROS2 Overview"


### PR DESCRIPTION
Closes #46. This pull requests builds on top of #51 and such should be merged **after** it. 

![edit_on_github_preview](https://user-images.githubusercontent.com/13500507/45969468-28b5a900-c00a-11e8-9b92-caf5414da267.png)


Currently, online edition button links are provided for documentation pages only.