### PR TITLE
fix url quoting

### DIFF
--- a/404.html
+++ b/404.html
@@ -10,7 +10,7 @@ title: "404: Not Found"
         <div class="container-fluid">
           <div class="row">
             <div class="col-md-6">
-              <img width=320 src={{ "/assets/404_icon.png" | prepend: site.baseurl }}>
+              <img width=320 src="{{ '/assets/404_icon.png' | prepend: site.baseurl }}">
             </div>
             <div class="col-md-6">
               <h1>This isn't the page you're looking for...</h1>

--- a/_includes/package_body.html
+++ b/_includes/package_body.html
@@ -443,7 +443,7 @@ Assumes distro and package are defined
   </div>
 </div>
 
-<script type="text/javascript" src={{ "/js/package_body_tabs.js" | prepend: site.baseurl }}></script>
+<script type="text/javascript" src="{{ '/js/package_body_tabs.js' | prepend: site.baseurl }}"></script>
 
 <script id="{{distro}}-question-list-template" type="text/html">
   <p>
@@ -466,11 +466,11 @@ Assumes distro and package are defined
   {% endraw %}
 </script>
 
-<script type="text/javascript" src={{ "/js/jquery.jfeed.pack.js" | prepend: site.baseurl }}></script>
-<link rel="stylesheet" type="text/css" href={{ "/css/prettify.css" | prepend: site.baseurl }}/>
-<script type="text/javascript" src={{ "/js/prettify.js" | prepend: site.baseurl }}></script>
-<script type="text/javascript" src={{ "/js/mustache.js" | prepend: site.baseurl }}></script>
-<script type="text/javascript" src={{ "/js/showdown.min.js" | prepend: site.baseurl }}></script>
+<script type="text/javascript" src="{{ '/js/jquery.jfeed.pack.js' | prepend: site.baseurl }}"></script>
+<link rel="stylesheet" type="text/css" href="{{ '/css/prettify.css' | prepend: site.baseurl }}"/>
+<script type="text/javascript" src="{{ '/js/prettify.js' | prepend: site.baseurl }}"></script>
+<script type="text/javascript" src="{{ '/js/mustache.js' | prepend: site.baseurl }}"></script>
+<script type="text/javascript" src="{{ '/js/showdown.min.js' | prepend: site.baseurl }}"></script>
 
 <script type="text/javascript">
 jQuery.browser = {};

--- a/_includes/package_header.html
+++ b/_includes/package_header.html
@@ -11,7 +11,7 @@ Assumes the following are defined:
     <table class="table">
       <tr>
         <td width="100px" class="text-center">
-          <img style="width: 30px" src={{ "/assets/repo.png" | prepend: site.baseurl }}>
+          <img style="width: 30px" src="{{ '/assets/repo.png' | prepend: site.baseurl }}">
         </td>
         <td>
           <h5>
@@ -25,7 +25,7 @@ Assumes the following are defined:
   <table class="table">
     <tr>
       <td width="100px" class="text-center">
-        <img style="width: 80px" src={{ "/assets/package.png" | prepend: site.baseurl }}>
+        <img style="width: 80px" src="{{ '/assets/package.png' | prepend: site.baseurl }}">
       </td>
       <td>
         <h3 style="margin-top: 5px">

--- a/_includes/package_info.html
+++ b/_includes/package_info.html
@@ -1,6 +1,6 @@
 <div class="well well-sm">
   <div class="top-buffer">
-    <h3><img style="width: 50px; margin-right: 5px;" src={{ "/assets/package.png" | prepend: site.baseurl }}>{{page.package_name}} <small>package</small></h3>
+    <h3><img style="width: 50px; margin-right: 5px;" src="{{ '/assets/package.png' | prepend: site.baseurl }}">{{page.package_name}} <small>package</small></h3>
   </div>
   <div class="top-buffer">
     {% for tag in page.repo.tags %}<span class="label label-default">{{ tag }}</span> {% endfor %}

--- a/_includes/repo_info.html
+++ b/_includes/repo_info.html
@@ -6,7 +6,7 @@
   <table class="table">
     <tr>
       <td width="100px" class="text-center">
-        <img style="width: 80px;" src={{ "/assets/repo.png" | prepend: site.baseurl }}>
+        <img style="width: 80px;" src="{{ '/assets/repo.png' | prepend: site.baseurl }}">
       </td>
       <td>
         <h3><a style="text-decoration:none;" href="{{site.baseurl }}/r/{{page.repo.name}}">{{page.repo.name}}</a> <small>repository</small></h3>

--- a/_layouts/dep.html
+++ b/_layouts/dep.html
@@ -16,7 +16,7 @@ layout: default
         <table class="table">
           <tr>
             <td width="100px" class="text-center">
-              {% comment %}<img style="width: 80px;" src={{ "/assets/repo.png" | prepend: site.baseurl }}>{% endcomment %}
+              {% comment %}<img style="width: 80px;" src="{{ '/assets/repo.png' | prepend: site.baseurl }}">{% endcomment %}
             </td>
             <td>
               <h3><a style="text-decoration:none;" href="{{site.baseurl}}/d/{{page.dep_name}}">{{page.dep_name}}</a> <small>system dep</small></h3>

--- a/_layouts/package_instances.html
+++ b/_layouts/package_instances.html
@@ -14,7 +14,7 @@ layout: default
     <div class="row">
       <div class="well well-sm">
         <div class="top-buffer">
-          <h3><img style="width: 50px; margin-right: 5px;" src={{ "/assets/package.png" | prepend: site.baseurl }}>{{page.package_name}} <small>package instances</small></h3>
+          <h3><img style="width: 50px; margin-right: 5px;" src="{{ '/assets/package.png' | prepend: site.baseurl }}">{{page.package_name}} <small>package instances</small></h3>
         </div>
         <div class="top-buffer">
           {% for tag in page.repo.tags %}<span class="label label-default">{{ tag }}</span> {% endfor %}

--- a/_layouts/repo_instance_distro.html
+++ b/_layouts/repo_instance_distro.html
@@ -82,7 +82,7 @@ layout: default
   </div>
 </div>
 
-<script src={{ "/js/repo_switch.js" | prepend: site.baseurl }}></script>
+<script src="{{ '/js/repo_switch.js' | prepend: site.baseurl }}"></script>
 
 <script>
 $(document).ready(function(){

--- a/_layouts/repo_instances.html
+++ b/_layouts/repo_instances.html
@@ -14,7 +14,7 @@ layout: default
     <div class="row">
       <div class="well well-sm">
         <div>
-          <h3><img style="width: 50px; margin-right: 5px;" src={{ "/assets/repo.png" | prepend: site.baseurl }}>{{page.repo_instances.name}} <small>repo instances</small></h3>
+          <h3><img style="width: 50px; margin-right: 5px;" src="{{ '/assets/repo.png' | prepend: site.baseurl }}">{{page.repo_instances.name}} <small>repo instances</small></h3>
         </div>
       </div>
     </div>

--- a/_layouts/repo_variant_distro.html
+++ b/_layouts/repo_variant_distro.html
@@ -81,7 +81,7 @@ layout: default
   </div>
 </div>
 
-<script src={{ "/js/repo_switch.js" | prepend: site.baseurl }}></script>
+<script src="{{ '/js/repo_switch.js' | prepend: site.baseurl }}"></script>
 
 <script>
 $(document).ready(function(){

--- a/about.md
+++ b/about.md
@@ -6,7 +6,7 @@ permalink: /about/
 
 # About
 
-<img style="margin-left: 40px; margin-right:40px; margin-bottom: 15px;" align="right" src={{ "/assets/rosindex_logo.png" | prepend: site.baseurl }} width="256">
+<img style="margin-left: 40px; margin-right:40px; margin-bottom: 15px;" align="right" src="{{ '/assets/rosindex_logo.png' | prepend: site.baseurl }}" width="256">
 
 ROS Index aims to be the *definitive index* of all ROS software. It aims to do this
 not only by indexing all known ROS packages listed in


### PR DESCRIPTION
The prepend was stripping the quotes and most cases were passing

I noticed broken links that has the urls wrong

![image](https://user-images.githubusercontent.com/447804/46009496-98607e00-c074-11e8-8d9c-94b01ffe4269.png)

