### PR TITLE
update baseurl for new hosting at index.ros.org

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+index.ros.org

--- a/index.yml
+++ b/index.yml
@@ -3,7 +3,7 @@ title: ROS Index
 #email: your-email@domain.com
 description: > # this means to ignore newlines until "baseurl:"
   a community-maintained index of robotics software
-baseurl: "/index.ros.org" # the subpath of your site, e.g. /blog/
+baseurl: "" # the subpath of your site, e.g. /blog/
 url: "https://ros-infrastructure.github.io/index.ros.org/" # the base hostname & protocol for your site
 #twitter_username: jekyllrb
 github_username:  rosindex


### PR DESCRIPTION
This is now hosted at index.ros.org without a prefix