### PR TITLE
Fix broken code links

### DIFF
--- a/_plugins/rosindex_generator.rb
+++ b/_plugins/rosindex_generator.rb
@@ -73,7 +73,7 @@ def get_browse_uri(uri_s, type, branch)
     path_split = uri_split[1].rpartition('.')
     repo_name = if path_split[1] == '.' then path_split[0] else path_split[-1] end
     puts uri_split
-    return 'https://github.com/%s/%s/blob/%s' % [uri_split[0].sub(/^\//, ''), repo_name, branch]
+    return 'https://github.com/%s/%s/tree/%s' % [uri_split[0].sub(/^\//, ''), repo_name, branch]
   when 'bitbucket.org'
     uri_split = File.split(uri.path)
     return 'https://bitbucket.org/%s/%s/src/%s' % [uri_split[0], uri_split[1], branch]


### PR DESCRIPTION
Fixes #63 
This PR fixes the link generated by `get_browse_uri` so that it's valid for both glob and tree URLs.