### PR TITLE
Improve documentation breadcrumbs

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -46,8 +46,8 @@
                   <ul class="dropdown-menu" role="menu" aria-labelledby="dLabel">
                     {% for repo in site.docs_repos %}
                     <li>
-                      <a href="{{site.baseurl}}/doc/{{ repo.name }}">
-                        {{ repo.description }}
+                      <a href="{{site.baseurl}}/doc/{{ repo[0] }}">
+                        {{ repo[1].description }}
                       </a>
                     </li>
                     {% endfor %}

--- a/_layouts/doc.html
+++ b/_layouts/doc.html
@@ -7,10 +7,21 @@ layout: default
     <div class="row">
       <ol class="breadcrumb">
         <li><a href="{{site.baseurl}}/">Home</a></li>
-        {% for bc in page.breadcrumbs %}
-        <li><a href="{{site.baseurl}}/{{bc}}">{{bc}}</a></li>
+        {% assign splitted_url = page.url | split:"/" %}
+        {% assign repo_name = splitted_url[2] %}
+        {% for repo in site.docs_repos %}
+          {% if repo.name == repo_name %}
+            {% assign description = repo.description %}
+          {% endif %}
         {% endfor %}
-        <li class="active">{{ page.title }}</li>
+        {% if splitted_url.size > 3 %}
+          {% for repo in site.docs_repos %}
+            {% if repo.name == repo_name %}
+              <li><a href="{{site.baseurl}}/doc/{{repo_name}}/">{{ repo.description }}</a></li>
+            {% endif %}
+          {% endfor %}
+        {% endif %}
+        <li class="active">{{ description }}</li>
       </ol>
       {% if page.edit_url %}
       <a type="button" href="{{ page.edit_url }}" class="btn btn-success pull-right">

--- a/_layouts/doc.html
+++ b/_layouts/doc.html
@@ -9,19 +9,20 @@ layout: default
         <li><a href="{{site.baseurl}}/">Home</a></li>
         {% assign splitted_url = page.url | split:"/" %}
         {% assign repo_name = splitted_url[2] %}
-        {% for repo in site.docs_repos %}
-          {% if repo.name == repo_name %}
-            {% assign description = repo.description %}
+        {% assign page_name = splitted_url[-1] %}
+
+        {% assign description = site.docs_repos[repo_name].description %}
+
+        {% if repo_name != page_name %}
+          <li><a href="{{site.baseurl}}/doc/{{repo_name}}/">{{ description }}</a></li>
+          {% if page.title == "" or page.title == nil  %}
+            <li class="active">{{ page_name | remove: ".html" }}</li>
+          {% else %}
+            <li class="active">{{ page.title }}</li>
           {% endif %}
-        {% endfor %}
-        {% if splitted_url.size > 3 %}
-          {% for repo in site.docs_repos %}
-            {% if repo.name == repo_name %}
-              <li><a href="{{site.baseurl}}/doc/{{repo_name}}/">{{ repo.description }}</a></li>
-            {% endif %}
-          {% endfor %}
+        {% else %}
+          <li class="active">{{ description }}</li>
         {% endif %}
-        <li class="active">{{ description }}</li>
       </ol>
       {% if page.edit_url %}
       <a type="button" href="{{ page.edit_url }}" class="btn btn-success pull-right">

--- a/_plugins/pulling_docs.rb
+++ b/_plugins/pulling_docs.rb
@@ -4,16 +4,16 @@ require 'fileutils'
 
 Jekyll::Hooks.register :site, :after_init do |site|
     site.config['docs_repos'].each do |repo|
-        src = File.join(site.source, "_remotes", repo["name"])
+        src = File.join(site.source, "_remotes", repo[0])
         dest_dir = File.join(site.source, "doc")
-        dest = File.join(dest_dir, repo["name"])
+        dest = File.join(dest_dir, repo[0])
         if File.directory?(dest)
           FileUtils.rm_r(dest)
         end
         if File.directory?(src)
             FileUtils.cp_r(src, dest_dir)
         else
-            raise IOError.new("Unable to copy from #{origin}, the directory doesn't exist.")
+            raise IOError.new("Unable to copy from #{src}, the directory doesn't exist.")
         end
     end
 end

--- a/_plugins/pulling_docs.rb
+++ b/_plugins/pulling_docs.rb
@@ -3,10 +3,10 @@
 require 'fileutils'
 
 Jekyll::Hooks.register :site, :after_init do |site|
-    site.config['docs_repos'].each do |repo|
-        src = File.join(site.source, "_remotes", repo[0])
+    site.config['docs_repos'].each do |key, value|
+        src = File.join(site.source, "_remotes", key)
         dest_dir = File.join(site.source, "doc")
-        dest = File.join(dest_dir, repo[0])
+        dest = File.join(dest_dir, key)
         if File.directory?(dest)
           FileUtils.rm_r(dest)
         end

--- a/index.yml
+++ b/index.yml
@@ -18,5 +18,5 @@ attic_file: _remotes/rosforks/attic.yaml
 # Indicates which of the repositories tracked in remotes.yml
 # correspond to documentation repos.
 docs_repos:
-  - name: ros2_overview
+  ros2_overview:
     description: "ROS2 Overview"


### PR DESCRIPTION
Fixes #18 

This implements what was suggested on [this comment](https://github.com/ros2/rosindex/issues/18#issuecomment-420844949):
- Display which repository the page is coming from, having a link back to the top level README for that repo.