### PR TITLE
Restructure Makefile to separate build stages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,17 +11,33 @@ cache_dir=$(deploy_dir)/cache
 
 config_file=_config.yml
 index_file=index.yml
+discover_config=_config/discover.yml
+update_config=_config/update.yml
+scrape_config=_config/scrape.yml
+search_config=_config/search_index.yml
+
+build: download-previous discover update scrape search-index
 
 # This target is invoked by a doc_independent job on the ROS buildfarm.
 html: build deploy
 
-# Clone a bunch of other repos part of the rosdistro and build the index.
-build:
+download-previous:
 	mkdir -p $(deploy_dir)
 	mkdir -p $(docs_dir)
 	mkdir -p $(remotes_dir)
 	vcs import --input $(remotes_file) --force $(remotes_dir)
-	bundle exec jekyll build --verbose --trace -d $(deploy_dir) --config=$(config_file),$(index_file)
+
+discover:
+	bundle exec jekyll build --verbose --trace -d $(deploy_dir) --config=$(config_file),$(index_file),$(discover_config)
+
+update:
+	bundle exec jekyll build --verbose --trace -d $(deploy_dir) --config=$(config_file),$(index_file),$(update_config)
+
+scrape:
+	bundle exec jekyll build --verbose --trace -d $(deploy_dir) --config=$(config_file),$(index_file),$(scrape_config)
+
+search-index:
+	bundle exec jekyll build --verbose --trace -d $(deploy_dir) --config=$(config_file),$(index_file),$(search_config)
 
 # deploy assumes build has run already
 deploy:

--- a/_config.yml
+++ b/_config.yml
@@ -34,15 +34,6 @@ report_diff_filename: _cache/_deploy_index_report_diff.yaml
 debbuild_release_path: _cache/debbuild_releases
 wiki_title_index_filename: _cache/ros_org_wiki_title_index.txt
 
-# If true, this skips finding repos based on the repo sources
-skip_discover: false
-# If true, this skips updating the known repos
-skip_update: false
-# If true, this skips scraping the cloned repos
-skip_scrape: false
-# If true, this skips generating the search index
-skip_search_index: false
-
 checkout_threads: 4
 checkout_path: "_plugins_data/checkout"
 

--- a/_config.yml
+++ b/_config.yml
@@ -60,6 +60,7 @@ domain_blacklist:
 exclude:
   - _scripts
   - _cache
+  - _config
   - _devel
   - _plugins_data
   - _remotes

--- a/_config/discover.yml
+++ b/_config/discover.yml
@@ -1,0 +1,8 @@
+# If true, this skips finding repos based on the repo sources
+skip_discover: false
+# If true, this skips updating the known repos
+skip_update: true
+# If true, this skips scraping the cloned repos
+skip_scrape: true
+# If true, this skips generating the search index
+skip_search_index: true

--- a/_config/scrape.yml
+++ b/_config/scrape.yml
@@ -1,0 +1,8 @@
+# If true, this skips finding repos based on the repo sources
+skip_discover: true
+# If true, this skips updating the known repos
+skip_update: true
+# If true, this skips scraping the cloned repos
+skip_scrape: false
+# If true, this skips generating the search index
+skip_search_index: true

--- a/_config/search_index.yml
+++ b/_config/search_index.yml
@@ -1,0 +1,8 @@
+# If true, this skips finding repos based on the repo sources
+skip_discover: true
+# If true, this skips updating the known repos
+skip_update: true
+# If true, this skips scraping the cloned repos
+skip_scrape: true
+# If true, this skips generating the search index
+skip_search_index: false

--- a/_config/update.yml
+++ b/_config/update.yml
@@ -1,0 +1,8 @@
+# If true, this skips finding repos based on the repo sources
+skip_discover: true
+# If true, this skips updating the known repos
+skip_update: false
+# If true, this skips scraping the cloned repos
+skip_scrape: true
+# If true, this skips generating the search index
+skip_search_index: true

--- a/_plugins/pulling_docs.rb
+++ b/_plugins/pulling_docs.rb
@@ -13,7 +13,8 @@ Jekyll::Hooks.register :site, :after_init do |site|
         if File.directory?(src)
             FileUtils.cp_r(src, dest_dir)
         else
-            raise IOError.new("Unable to copy from #{src}, the directory doesn't exist.")
+            raise IOError.new("Unable to copy from #{src}, the directory doesn't exist.\n"\
+              "Please ensure the \"download-previous\" target has run prior to this one.\n")
         end
     end
 end


### PR DESCRIPTION
Fixes #61 
This PR restructures the project's Makefile by adding custom targets for each of the build stages.