### PR TITLE
Enable inter-sphinx cross referencing

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,3 +114,6 @@ Deployment is done by calling the following make command:
 ```
 make deploy
 ```
+
+# Cross referencing documentation
+It's possible to cross reference packages that have been documented with Sphinx within rosindex. Please refer to [this document](https://github.com/ros2/ros2_documentation/blob/master/Inter-Sphinx-Example.rst) to get more information.

--- a/_sphinx/conf.py
+++ b/_sphinx/conf.py
@@ -66,6 +66,21 @@ pygments_style = 'sphinx'
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False
 
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+extensions = ['sphinx.ext.intersphinx']
+
+# Intersphinx mapping
+
+intersphinx_mapping = {
+    'catkin_pkg':    ('http://docs.ros.org/independent/api/catkin_pkg/html', None),
+    'jenkins_tools': ('http://docs.ros.org/independent/api/jenkins_tools/html', None),
+    'rosdep':        ('http://docs.ros.org/independent/api/rosdep/html', None),
+    'rosdistro':     ('http://docs.ros.org/independent/api/rosdistro/html', None),
+    'rosinstall':    ('http://docs.ros.org/independent/api/rosinstall/html', None),
+    'rospkg':        ('http://docs.ros.org/independent/api/rospkg/html', None),
+    'vcstools':      ('http://docs.ros.org/independent/api/vcstools/html', None)
+}
 
 # -- Options for HTML output ----------------------------------------------
 


### PR DESCRIPTION
This PR goes hand-by-hand with [ros2_documentation#6](https://github.com/ros2/ros2_documentation/pull/6), which documents how to make use of this functionality.
- Enables cross-referencing of packages with Sphinx within documentation (`rst` files only).
