### PR TITLE
ardent is still a supported distro

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -73,13 +73,13 @@ index_old_doc_paths: false
 #
 distros:
   - 'bouncy'
+  - 'ardent'
   - 'melodic'
   - 'lunar'
   - 'kinetic'
   - 'indigo'
 
 old_distros:
-  - 'ardent'
   - 'jade'
   - 'hydro'
   


### PR DESCRIPTION
See this comment: https://github.com/ros2/rosindex/commit/4e6bd10a5319ff11925f7d1e5a9b378ed0995eee#r30974006