### PR TITLE
Catch RSS parse failure and display error to user

### DIFF
--- a/_includes/package_body.html
+++ b/_includes/package_body.html
@@ -433,11 +433,14 @@ Assumes distro and package are defined
   <div class="tab-pane" id="{{distro}}-questions">
     <div class="panel panel-default">
       <div class="panel-heading">
-        <h3 class="panel-title">Answers.ros.org Recent Questions Tagged: <kbd>{{package.name}}</kbd></h3>
+        <h3 class="panel-title">Recent questions tagged <kbd>{{package.name}}</kbd> at <strong><a href="https://answers.ros.org" target="_blank">answers.ros.org</a></strong></h3>
       </div>
       <div id="{{distro}}-question-list" class="panel-body" style="display: none;"></div>
       <div id="{{distro}}-no-question-list" class="panel-body" style="display: none;">
         <p>No questions yet, you can ask one <a href="https://answers.ros.org/questions/ask/?tags={{package.name}},{{distro}}">here</a>.</p>
+      </div>
+      <div id="{{distro}}-get-question-fail" class="panel-body alert alert-warning" style="display: none;">
+        <p>Failed to get question list, you can ticket an issue <a href="https://github.com/ros2/rosindex/issues/new" target="_blank" class="alert-link">here</a> </p>
       </div>
     </div>
   </div>
@@ -508,6 +511,10 @@ jQuery(function() {
               jQuery("#{{distro}}-no-question-list").show();
             }
             jQuery("#{{distro}}-questions-count").text(feed.items.length);
+        },
+        error: function(res, err) {
+          console.error("Failed to get feed:", err)
+          jQuery("#{{distro}}-get-question-fail").show();
         }
     });
 });


### PR DESCRIPTION
Mitigate some of #94 by catching the RSS parsing error and displaying a message to the user. I wouldn't close that issue until we fix the parsing though.

Also changed the styling a bit.

![getquestionfail](https://user-images.githubusercontent.com/5751272/47518689-8541f900-d840-11e8-8ac3-7125806c480e.png)
