### PR TITLE
fix parenthesis order

### DIFF
--- a/404.html
+++ b/404.html
@@ -44,5 +44,5 @@ title: "404: Not Found"
 <script>
 $(function () {
     // TODO add url to the report button
-  )};
+  };)
 </script>


### PR DESCRIPTION
Fixes a warning in the 404 page.

`Uncaught SyntaxError: Unexpected token )`