### PR TITLE
Uses the newest available distro on first package or repo page load

### DIFF
--- a/_layouts/deps.html
+++ b/_layouts/deps.html
@@ -120,3 +120,8 @@ layout: default
 </div>
 
 <script src="/js/distro_switch.js"></script>
+<script type="text/javascript">
+  $(document).ready(function() {
+    setupDistroSwitch("{{ site.distros[0] }}");
+  });
+</script>

--- a/_layouts/package.html
+++ b/_layouts/package.html
@@ -51,4 +51,8 @@ layout: default
   </div>
 {% endfor %}
 
-
+<script type="text/javascript">
+  $(document).ready(function() {
+    setupDistroSwitch("{{ page.default_distro }}");
+  });
+</script>

--- a/_layouts/package_instance.html
+++ b/_layouts/package_instance.html
@@ -54,3 +54,8 @@ layout: default
   </div>
 {% endfor %}
 
+<script type="text/javascript">
+  $(document).ready(function() {
+    setupDistroSwitch("{{ page.default_distro }}");
+  });
+</script>

--- a/_layouts/packages.html
+++ b/_layouts/packages.html
@@ -138,3 +138,8 @@ layout: default
   </div>
 </div>
 
+<script type="text/javascript">
+  $(document).ready(function() {
+    setupDistroSwitch("{{ site.distros[0] }}");
+  });
+</script>

--- a/_layouts/repo_instance.html
+++ b/_layouts/repo_instance.html
@@ -94,3 +94,8 @@ layout: default
   </div>
 {% endfor %}
 
+<script type="text/javascript">
+  $(document).ready(function() {
+    setupDistroSwitch("{{ page.default_distro }}");
+  });
+</script>

--- a/_layouts/repo_instance_distro.html
+++ b/_layouts/repo_instance_distro.html
@@ -85,13 +85,15 @@ layout: default
 <script src="{{ '/js/repo_switch.js' | prepend: site.baseurl }}"></script>
 
 <script>
-$(document).ready(function(){
-                  $('#content-tabs a').click(
-                      function (e) {
-                      //e.preventDefault();
-                      $(this).tab('show');
-                      console.log(this)
-                      });
-                  });
+$(document).ready(function() {
+  setupDistroSwitch("{{ site.distros[0] }}");
+  $('#content-tabs a').click(
+    function (e) {
+      //e.preventDefault();
+      $(this).tab('show');
+      console.log(this)
+    }
+  );
+});
 </script>
 

--- a/_layouts/repo_variant_distro.html
+++ b/_layouts/repo_variant_distro.html
@@ -84,13 +84,14 @@ layout: default
 <script src="{{ '/js/repo_switch.js' | prepend: site.baseurl }}"></script>
 
 <script>
-$(document).ready(function(){
-                  $('#content-tabs a').click(
-                      function (e) {
-                      //e.preventDefault();
-                      $(this).tab('show');
-                      console.log(this)
-                      });
-                  });
+$(document).ready(function() {
+  setupDistroSwitch("{{ site.distros[0] }}");
+  $('#content-tabs a').click(
+    function (e) {
+      //e.preventDefault();
+      $(this).tab('show');
+      console.log(this)
+    }
+  );
+});
 </script>
-

--- a/_layouts/repos.html
+++ b/_layouts/repos.html
@@ -135,4 +135,8 @@ layout: default
   </div>
 </div>
 
-
+<script type="text/javascript">
+  $(document).ready(function() {
+    setupDistroSwitch("{{ site.distros[0] }}");
+  });
+</script>

--- a/_layouts/system_deps.html
+++ b/_layouts/system_deps.html
@@ -109,3 +109,8 @@ layout: default
   </div>
 </div>
 
+<script type="text/javascript">
+  $(document).ready(function() {
+    setupDistroSwitch("{{ site.distros[0] }}");
+  });
+</script>

--- a/_plugins/pre_configuration.rb
+++ b/_plugins/pre_configuration.rb
@@ -1,6 +1,6 @@
 Jekyll::Hooks.register :site, :after_init  do |site|
-  site.config['distros'] = site.config['ros_distros'] +
-                           site.config['ros2_distros']
-  site.config['old_distros'] = site.config['old_ros_distros'] +
-                               site.config['old_ros2_distros']
+  site.config['distros'] = site.config['ros2_distros'] +
+                           site.config['ros_distros']
+  site.config['old_distros'] = site.config['old_ros2_distros'] +
+                               site.config['old_ros_distros']
 end

--- a/_ruby_libs/pages.rb
+++ b/_ruby_libs/pages.rb
@@ -75,9 +75,14 @@ class RepoPage < Jekyll::Page
     self.data['instance_index_url'] = File.join('repos', repo.name)
     self.data['default_instance_id'] = instances.default.id
 
-    self.data['available_distros'], self.data['available_older_distros'], self.data['n_available_older_distros'] = get_available_distros(site, repo.snapshots)
-
+    self.data['available_distros'],
+    self.data['available_older_distros'],
+    self.data['n_available_older_distros'] = get_available_distros(site, repo.snapshots)
     self.data['all_distros'] = site.config['distros'] + site.config['old_distros']
+
+    self.data['default_distro'] = self.data['available_distros'].keys.first or
+                                  self.data['available_older_distros'].keys.first or
+                                  self.data['all_distros'].first
   end
 end
 
@@ -208,9 +213,14 @@ class PackagePage < Jekyll::Page
     self.data['instance_index_url'] = File.join('packages',package_instances.name)
     self.data['instance_base_url'] = @dir
 
-    self.data['available_distros'], self.data['available_older_distros'], self.data['n_available_older_distros'] = get_available_distros(site, package_instances.snapshots)
-
+    self.data['available_distros'],
+    self.data['available_older_distros'],
+    self.data['n_available_older_distros'] = get_available_distros(site, package_instances.snapshots)
     self.data['all_distros'] = site.config['distros'] + site.config['old_distros']
+
+    self.data['default_distro'] = self.data['available_distros'].keys.first or
+                                  self.data['available_older_distros'].keys.first or
+                                  self.data['all_distros'].first
   end
 end
 
@@ -258,6 +268,10 @@ class PackageInstancePage < Jekyll::Page
     self.data['n_available_older_distros'] = self.data['available_older_distros'].values.count(true)
 
     self.data['all_distros'] = site.config['distros'] + site.config['old_distros']
+
+    self.data['default_distro'] = self.data['available_distros'].keys.first or
+                                  self.data['available_older_distros'].keys.first or
+                                  self.data['all_distros'].first
   end
 end
 

--- a/js/distro_switch.js
+++ b/js/distro_switch.js
@@ -1,5 +1,4 @@
-
-function setupDistroSwitch(default_distro) { 
+function setupDistroSwitch(default_distro) {
   $('#distro-switch label').click(function (e) {
     console.log(e.target)
     // get the distro and set the cookie
@@ -55,7 +54,7 @@ function setupDistroSwitch(default_distro) {
   }
 
   if(typeof distro == 'undefined') {
-    distro = default_distro;    
+    distro = default_distro;
   }
 
   $('.distro').not('.distro-'+distro).hide(0);
@@ -63,4 +62,3 @@ function setupDistroSwitch(default_distro) {
   $('#'+distro+'-option').addClass('active');
   $('#'+distro+'-button').trigger("click");
 }
-

--- a/js/distro_switch.js
+++ b/js/distro_switch.js
@@ -1,7 +1,5 @@
----
----
 
-$(document).ready(function(){ 
+function setupDistroSwitch(default_distro) { 
   $('#distro-switch label').click(function (e) {
     console.log(e.target)
     // get the distro and set the cookie
@@ -57,12 +55,12 @@ $(document).ready(function(){
   }
 
   if(typeof distro == 'undefined') {
-    distro = "{{site.distros[0]}}";
+    distro = default_distro;    
   }
 
   $('.distro').not('.distro-'+distro).hide(0);
   $('.distro-'+distro).show(0);
   $('#'+distro+'-option').addClass('active');
   $('#'+distro+'-button').trigger("click");
-});
+}
 


### PR DESCRIPTION
Closes #97 by ensuring that, on first page load, when no preferred ros distro has been previously selected, we default to newest available distro for that package or repo.