### PR TITLE
Add standard ROS header

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -2,8 +2,28 @@
 
   <div class="wrapper">
     <div class="container-fluid" style="margin-bottom: 10px">
-      <div class="row">
 
+      <div align="center">
+        <br>
+        <table id="topnav-table">
+          <tr>
+            <td valign="middle">
+                ROS Resources:
+              <a href="http://wiki.ros.org/">Documentation</a>
+              |
+              <a href="http://wiki.ros.org/Support">Support</a>
+              |
+              <a href="http://discourse.ros.org/">Discussion Forum</a>
+              |
+              <a href="http://status.ros.org/">Service Status</a>
+              |
+              <a href="http://answers.ros.org/">Q&A answers.ros.org</a>
+            </td>
+          </tr>
+        </table> <!-- topnav-table -->
+      </div>
+
+      <div class="row">
 
         <div class="col-sm-12 col-md-9" style="margin-top: 8px">
           <div class="row">


### PR DESCRIPTION
Closes #116 
- Adds the standard ROS header bar at top of rosindex's header.
- Keep links to default locations as suggested [here](https://github.com/ros-infrastructure/rosindex/issues/116#issuecomment-438014195).