### PR TITLE
Adding rosdeps to index

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -98,6 +98,9 @@ old_ros_distros:
   - 'jade'
   - 'hydro'
 
+system_deps_distros:
+  - 'N/A'
+
 # package list page
 packages_per_page: 50
 repos_per_page: 50

--- a/_layouts/package_search.html
+++ b/_layouts/package_search.html
@@ -50,6 +50,7 @@ layout: default
   <table class="table table-condensed table-striped table-hover">
     <thead>
       <tr>
+        <th class="col-xs-1" style="text-align: center;"><span class="glyphicon glyphicon-question-sign" title="Type"></span></th>
         <th class="col-xs-1" style="text-align: center;"><span class="glyphicon glyphicon-flash" title="Release status"></span></th>
         <th class="col-xs-1" style="text-align: center;"><span class="glyphicon glyphicon-file" title="README status"></span></th>
         <th class="col-xs-1" style="text-align: center;"><span class="glyphicon glyphicon-time" title="Last commit date"></span></th>
@@ -61,6 +62,7 @@ layout: default
     <tbody class="entries">
       {{#entries}}
       <tr>
+        <td class="col-xs-1" align="center"><span class="label label-default">{{type}}</span></td>
         {{#released}}
         <td class="text-center col-xs-1">
           <span title="Released" data-toggle="tooltip" data-placement="left" class="glyphicon glyphicon-flash"></span>

--- a/_plugins/rosindex_generator.rb
+++ b/_plugins/rosindex_generator.rb
@@ -1418,7 +1418,8 @@ class Indexer < Jekyll::Generator
               'distro' => distro,
               'instance' => repo.id,
               'readme' => readme_filtered,
-              'system_deps' => p['system_deps'].keys.to_s
+              'system_deps' => p['system_deps'].keys.to_s,
+              'type' => 'Package'
             }
             dputs 'indexed: ' << "#{package_name} #{instance_id} #{distro}"
           end
@@ -1445,7 +1446,8 @@ class Indexer < Jekyll::Generator
           'distro' => site.config['system_deps_distros'][0],
           'instance' => '',
           'readme' => '',
-          'system_deps' => ''
+          'system_deps' => '',
+          'type' => 'System dependency'
         }
       end
 

--- a/_plugins/rosindex_generator.rb
+++ b/_plugins/rosindex_generator.rb
@@ -1417,9 +1417,9 @@ class Indexer < Jekyll::Generator
               'authors' => p['authors'] * " ",
               'distro' => distro,
               'instance' => repo.id,
-              'readme' => readme_filtered
+              'readme' => readme_filtered,
+              'system_deps' => p['system_deps'].keys.to_s
             }
-
             dputs 'indexed: ' << "#{package_name} #{instance_id} #{distro}"
           end
         end
@@ -1445,7 +1445,8 @@ class Indexer < Jekyll::Generator
         '-f','distro',
         '-f','readme',
         '-f','released',
-        '-f','unreleased'
+        '-f','unreleased',
+        '-f','system_deps'
       ].join(' ')
       lunr_build_full_cmd = "#{lunr_build_index_cmd} #{lunr_build_index_fields}"
 

--- a/_plugins/rosindex_generator.rb
+++ b/_plugins/rosindex_generator.rb
@@ -769,7 +769,7 @@ class Indexer < Jekyll::Generator
 
     # construct list of known ros distros
     $recent_distros = site.config['distros']
-    $all_distros = site.config['distros'] + site.config['old_distros']
+    $all_distros = site.config['distros'] + site.config['old_distros'] + site.config['system_deps_distros']
     $ros_distros = site.config['ros_distros'] +
                     site.config['old_ros_distros']
     $ros2_distros = site.config['ros2_distros'] +
@@ -1423,6 +1423,30 @@ class Indexer < Jekyll::Generator
             dputs 'indexed: ' << "#{package_name} #{instance_id} #{distro}"
           end
         end
+      end
+
+      @rosdeps.each do |dep_name, full_dep_data|
+        puts dep_name.blue
+        puts full_dep_data.to_s
+        index << {
+          'id' => index.length,
+          'baseurl' => site.config['baseurl'],
+          'url' => File.join('/d', dep_name),
+          'last_commit_time' => '',
+          'tags' => '',
+          'name' => dep_name,
+          'repo_name' => '',
+          'released' => 'is:released',
+          'unreleased' => '',
+          'version' => '',
+          'description' => '',
+          'maintainers' => '',
+          'authors' => '',
+          'distro' => site.config['system_deps_distros'][0],
+          'instance' => '',
+          'readme' => '',
+          'system_deps' => ''
+        }
       end
 
       # precompute the lunr index


### PR DESCRIPTION
This addresses #101.

Now when a system dependency is searched for, the list of packages that use it appear as results, as well as the dependency itself. A new column was added to the search template to distinguish between packages and system dependencies; in the future that column can be used for documentation pages as well. As it would be a sort of "enum", we could also use glyphs for each case instead of plain text.

The following image shows a reduced example:
![image](https://user-images.githubusercontent.com/2480899/49673635-e0752700-fa4d-11e8-9225-af3a15bcaa4b.png)

Comments are welcome! /cc @tfoote @hidmic 