### PR TITLE
Revert "Fixes local links in repo and package READMEs"

### DIFF
--- a/_plugins/rosindex_generator.rb
+++ b/_plugins/rosindex_generator.rb
@@ -34,12 +34,12 @@ def get_ros_api(elem)
   return []
 end
 
-def get_readme(site, path, raw_uri, browse_uri)
-  return get_md_rst_txt(site, path, "README*", raw_uri, browse_uri)
+def get_readme(site, path, raw_uri)
+  return get_md_rst_txt(site, path, "README*", raw_uri)
 end
 
-def get_changelog(site, path, raw_uri, browse_uri)
-  return get_md_rst_txt(site, path, "CHANGELOG*", raw_uri, browse_uri)
+def get_changelog(site, path, raw_uri)
+  return get_md_rst_txt(site, path, "CHANGELOG*", raw_uri)
 end
 
 # Get a raw URI from a repo uri
@@ -310,7 +310,7 @@ class Indexer < Jekyll::Generator
       # Iterate over each of the readme file paths that were explicitly declared in package
       readmes = Array.new
       readmes_relpath.each do |readme_relpath|
-        tmp_readme_rendered, tmp_readme  = get_md_rst_txt(site, path, readme_relpath, raw_uri, browse_uri)
+        tmp_readme_rendered, tmp_readme  = get_md_rst_txt(site, path, readme_relpath, raw_uri)
         readme = {
           'browse_uri' => File.join(browse_uri, readme_relpath),
           'readme' => tmp_readme,
@@ -328,7 +328,7 @@ class Indexer < Jekyll::Generator
       end
 
       # check for changelog in same directory as package.xml
-      changelog_rendered, changelog = get_changelog(site, path, raw_uri, browse_uri)
+      changelog_rendered, changelog = get_changelog(site, path, raw_uri)
 
       # TODO: don't do this for cmake-based packages
       # look for launchfiles in this package
@@ -473,7 +473,9 @@ class Indexer < Jekyll::Generator
 
     # load the repo readme for this branch if it exists
     data['readme_rendered'], data['readme'] = get_readme(
-      site, vcs.local_path, data['raw_uri'], data['browse_uri'])
+      site,
+      vcs.local_path,
+      data['raw_uri'])
 
     unless repo.release_manifests[distro].nil?
       package_info = extract_package(site, distro, repo, snapshot, vcs.local_path, vcs.local_path, 'catkin', repo.release_manifests[distro])


### PR DESCRIPTION
Reverts ros-infrastructure/rosindex#125

This appears to be running on the scraped content too not just the docs.

We had an error in the test run: 
```
00:33:36.573 [1;31mERROR (find-object-googlecode-svn-trunk-ros-pkg-find_object_2d): Could not reach svn repository at uri: http://find-object.googlecode.com/svn/trunk/ros-pkg/find_object_2d: Code 404 bad URI: http://find-object.googlecode.com/svn/trunk/ros-pkg/find_object_2d[0m
00:33:36.573 [21.21%] Scraping github-introlab-find-object...
00:33:36.581 [1;33m --- no version for find_object_2d instance: github-introlab-find-object distro: crystal[0m
00:33:36.582 [1;33m --- no version for find_object_2d instance: github-introlab-find-object distro: bouncy[0m
00:33:36.583 [1;34m --- scraping version for find_object_2d instance: github-introlab-find-object distro: melodic[0m
00:33:36.620 /home/jenkins-agent/.bundle/gems/addressable-2.5.2/lib/addressable/uri.rb:874:in `scheme=': Invalid scheme format: %5BOpenCV%5D(http (Addressable::URI::InvalidURIError)
00:33:36.621 	from /home/jenkins-agent/.bundle/gems/addressable-2.5.2/lib/addressable/uri.rb:799:in `block in initialize'
00:33:36.621 	from /home/jenkins-agent/.bundle/gems/addressable-2.5.2/lib/addressable/uri.rb:2355:in `defer_validation'
00:33:36.621 	from /home/jenkins-agent/.bundle/gems/addressable-2.5.2/lib/addressable/uri.rb:796:in `initialize'
00:33:36.621 	from /home/jenkins-agent/.bundle/gems/addressable-2.5.2/lib/addressable/uri.rb:136:in `new'
00:33:36.621 	from /home/jenkins-agent/.bundle/gems/addressable-2.5.2/lib/addressable/uri.rb:136:in `parse'
00:33:36.621 	from /tmp/doc_repository/_ruby_libs/text_rendering.rb:25:in `block in fix_local_links'
00:33:36.621 	from /home/jenkins-agent/.bundle/gems/nokogiri-1.8.5/lib/nokogiri/xml/node_set.rb:204:in `block in each'
00:33:36.621 	from /home/jenkins-agent/.bundle/gems/nokogiri-1.8.5/lib/nokogiri/xml/node_set.rb:203:in `upto'
00:33:36.621 	from /home/jenkins-agent/.bundle/gems/nokogiri-1.8.5/lib/nokogiri/xml/node_set.rb:203:in `each'
00:33:36.621 	from /tmp/doc_repository/_ruby_libs/text_rendering.rb:24:in `fix_local_links'
00:33:36.621 	from /tmp/doc_repository/_ruby_libs/text_rendering.rb:80:in `get_md_rst_txt'
00:33:36.621 	from /tmp/doc_repository/_plugins/rosindex_generator.rb:38:in `get_readme'
00:33:36.621 	from /tmp/doc_repository/_plugins/rosindex_generator.rb:475:in `scrape_version'
00:33:36.621 	from /tmp/doc_repository/_plugins/rosindex_generator.rb:570:in `block in scrape_repo'
00:33:36.621 	from /tmp/doc_repository/_plugins/rosindex_generator.rb:539:in `each'
00:33:36.621 	from /tmp/doc_repository/_plugins/rosindex_generator.rb:539:in `scrape_repo'
00:33:36.621 	from /tmp/doc_repository/_plugins/rosindex_generator.rb:1207:in `block in generate'
00:33:36.621 	from /tmp/doc_repository/_plugins/rosindex_generator.rb:1201:in `each'
00:33:36.621 	from /tmp/doc_repository/_plugins/rosindex_generator.rb:1201:in `generate'
00:33:36.621 	from /home/jenkins-agent/.bundle/gems/jekyll-3.8.4/lib/jekyll/site.rb:175:in `block in generate'
00:33:36.621 	from /home/jenkins-agent/.bundle/gems/jekyll-3.8.4/lib/jekyll/site.rb:173:in `each'
00:33:36.621 	from /home/jenkins-agent/.bundle/gems/jekyll-3.8.4/lib/jekyll/site.rb:173:in `generate'
00:33:36.621 	from /home/jenkins-agent/.bundle/gems/jekyll-3.8.4/lib/jekyll/site.rb:70:in `process'
00:33:36.621 	from /home/jenkins-agent/.bundle/gems/jekyll-3.8.4/lib/jekyll/command.rb:28:in `process_site'
00:33:36.621 	from /home/jenkins-agent/.bundle/gems/jekyll-3.8.4/lib/jekyll/commands/build.rb:65:in `build'
00:33:36.621 	from /home/jenkins-agent/.bundle/gems/jekyll-3.8.4/lib/jekyll/commands/build.rb:36:in `process'
00:33:36.621 	from /home/jenkins-agent/.bundle/gems/jekyll-3.8.4/lib/jekyll/commands/build.rb:18:in `block (2 levels) in init_with_program'
00:33:36.621 	from /home/jenkins-agent/.bundle/gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `block in execute'
00:33:36.621 	from /home/jenkins-agent/.bundle/gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `each'
00:33:36.621 	from /home/jenkins-agent/.bundle/gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `execute'
00:33:36.621 	from /home/jenkins-agent/.bundle/gems/mercenary-0.3.6/lib/mercenary/program.rb:42:in `go'
00:33:36.621 	from /home/jenkins-agent/.bundle/gems/mercenary-0.3.6/lib/mercenary.rb:19:in `program'
00:33:36.621 	from /home/jenkins-agent/.bundle/gems/jekyll-3.8.4/exe/jekyll:15:in `<top (required)>'
00:33:36.621 	from /home/jenkins-agent/.bundle/bin/jekyll:23:in `load'
00:33:36.621 	from /home/jenkins-agent/.bundle/bin/jekyll:23:in `<main>'
00:33:37.564 make: *** [build] Error 1
```