### PR TITLE
Re-enable feature to fix local links in repo and package READMEs

### DIFF
--- a/_plugins/rosindex_generator.rb
+++ b/_plugins/rosindex_generator.rb
@@ -34,12 +34,12 @@ def get_ros_api(elem)
   return []
 end
 
-def get_readme(site, path, raw_uri)
-  return get_md_rst_txt(site, path, "README*", raw_uri)
+def get_readme(site, path, raw_uri, browse_uri)
+  return get_md_rst_txt(site, path, "README*", raw_uri, browse_uri)
 end
 
-def get_changelog(site, path, raw_uri)
-  return get_md_rst_txt(site, path, "CHANGELOG*", raw_uri)
+def get_changelog(site, path, raw_uri, browse_uri)
+  return get_md_rst_txt(site, path, "CHANGELOG*", raw_uri, browse_uri)
 end
 
 # Get a raw URI from a repo uri
@@ -310,7 +310,7 @@ class Indexer < Jekyll::Generator
       # Iterate over each of the readme file paths that were explicitly declared in package
       readmes = Array.new
       readmes_relpath.each do |readme_relpath|
-        tmp_readme_rendered, tmp_readme  = get_md_rst_txt(site, path, readme_relpath, raw_uri)
+        tmp_readme_rendered, tmp_readme  = get_md_rst_txt(site, path, readme_relpath, raw_uri, browse_uri)
         readme = {
           'browse_uri' => File.join(browse_uri, readme_relpath),
           'readme' => tmp_readme,
@@ -328,7 +328,7 @@ class Indexer < Jekyll::Generator
       end
 
       # check for changelog in same directory as package.xml
-      changelog_rendered, changelog = get_changelog(site, path, raw_uri)
+      changelog_rendered, changelog = get_changelog(site, path, raw_uri, browse_uri)
 
       # TODO: don't do this for cmake-based packages
       # look for launchfiles in this package
@@ -473,9 +473,7 @@ class Indexer < Jekyll::Generator
 
     # load the repo readme for this branch if it exists
     data['readme_rendered'], data['readme'] = get_readme(
-      site,
-      vcs.local_path,
-      data['raw_uri'])
+      site, vcs.local_path, data['raw_uri'], data['browse_uri'])
 
     unless repo.release_manifests[distro].nil?
       package_info = extract_package(site, distro, repo, snapshot, vcs.local_path, vcs.local_path, 'catkin', repo.release_manifests[distro])

--- a/_ruby_libs/text_rendering.rb
+++ b/_ruby_libs/text_rendering.rb
@@ -17,13 +17,27 @@ end
 def fix_local_links(text, raw_uri, browse_uri)
   readme_doc = Nokogiri::HTML(text)
   readme_doc.css("img[src]").each() do |img|
-    unless Addressable::URI.parse(img['src']).absolute?
-      img['src'] = raw_uri + "/" + img['src']
+    begin
+      unless Addressable::URI.parse(img['src']).absolute?
+        img['src'] = raw_uri + "/" + img['src']
+      end
+    rescue Exception
+      # If alt is defined displays it, removing the img otherwise
+      unless img['alt'].empty? do
+        img.replace(img['alt'])
+      else
+        img.remove
+      end
     end
   end
   readme_doc.css("a[href]").each() do |a|
-    unless Addressable::URI.parse(a['href']).absolute?
-      a['href'] = browse_uri + "/" + a['href']
+    begin
+      unless Addressable::URI.parse(a['href']).absolute?
+        a['href'] = browse_uri + "/" + a['href']
+      end
+    rescue Exception
+      # Removes the ill-formed href leaving the only base word
+      a.replace(a.content)
     end
   end
   readme_doc.at('body').inner_html

--- a/_ruby_libs/text_rendering.rb
+++ b/_ruby_libs/text_rendering.rb
@@ -16,26 +16,26 @@ end
 # Modifies markdown local links so that they link to github user content
 def fix_local_links(text, raw_uri, browse_uri)
   readme_doc = Nokogiri::HTML(text)
-  readme_doc.css("img[src]").each() do |img|
+  readme_doc.css("img[src]").each do |img|
     begin
       unless Addressable::URI.parse(img['src']).absolute?
         img['src'] = raw_uri + "/" + img['src']
       end
-    rescue Exception
+    rescue InvalidURIError
       # If alt is defined displays it, removing the img otherwise
-      unless img['alt'].empty? do
+      unless img['alt'].empty?
         img.replace(img['alt'])
       else
         img.remove
       end
     end
   end
-  readme_doc.css("a[href]").each() do |a|
+  readme_doc.css("a[href]").each do |a|
     begin
       unless Addressable::URI.parse(a['href']).absolute?
         a['href'] = browse_uri + "/" + a['href']
       end
-    rescue Exception
+    rescue InvalidURIError
       # Removes the ill-formed href leaving the only base word
       a.replace(a.content)
     end

--- a/_ruby_libs/text_rendering.rb
+++ b/_ruby_libs/text_rendering.rb
@@ -21,7 +21,8 @@ def fix_local_links(text, raw_uri, browse_uri)
       unless Addressable::URI.parse(img['src']).absolute?
         img['src'] = raw_uri + "/" + img['src']
       end
-    rescue InvalidURIError
+    rescue Addressable::URI::InvalidURIError
+      puts " --- WARNING: Markdown image link is ill-formed and had to be disabled: #{img['src'].to_s}".yellow
       # If alt is defined displays it, removing the img otherwise
       unless img['alt'].empty?
         img.replace(img['alt'])
@@ -35,7 +36,8 @@ def fix_local_links(text, raw_uri, browse_uri)
       unless Addressable::URI.parse(a['href']).absolute?
         a['href'] = browse_uri + "/" + a['href']
       end
-    rescue InvalidURIError
+    rescue Addressable::URI::InvalidURIError
+      puts " --- WARNING: Markdown link is ill-formed and had to be disabled: #{a['href'].to_s}".yellow
       # Removes the ill-formed href leaving the only base word
       a.replace(a.content)
     end


### PR DESCRIPTION
This PR re-enables changes made in #125 and:
Adds the proper handling mechanisms to avoid breaking a whole build instance by:
- Removing the invalid `href`s but leaving its content.
- Removing the invalid `img`s, attempting to show its `alt` (if valid), fully removing it otherwise.