### PR TITLE
Add nil check for img alt attribute.

### DIFF
--- a/_ruby_libs/text_rendering.rb
+++ b/_ruby_libs/text_rendering.rb
@@ -24,7 +24,7 @@ def fix_local_links(text, raw_uri, browse_uri)
     rescue Addressable::URI::InvalidURIError
       puts " --- WARNING: Markdown image link is ill-formed and had to be disabled: #{img['src'].to_s}".yellow
       # If alt is defined displays it, removing the img otherwise
-      unless img['alt'].empty?
+      unless img['alt'].nil? || img['alt'].empty?
         img.replace(img['alt'])
       else
         img.remove


### PR DESCRIPTION
Resolves:
```
    /tmp/doc_repository/_ruby_libs/text_rendering.rb:27:in `rescue in block in fix_local_links': undefined method `empty?' for nil:NilClass (NoMethodError)
        from /tmp/doc_repository/_ruby_libs/text_rendering.rb:20:in `block in fix_local_links'
        from /home/jenkins-agent/.bundle/gems/nokogiri-1.8.5/lib/nokogiri/xml/node_set.rb:204:in `block in each'
        from /home/jenkins-agent/.bundle/gems/nokogiri-1.8.5/lib/nokogiri/xml/node_set.rb:203:in `upto'
        from /home/jenkins-agent/.bundle/gems/nokogiri-1.8.5/lib/nokogiri/xml/node_set.rb:203:in `each'
        from /tmp/doc_repository/_ruby_libs/text_rendering.rb:19:in `fix_local_links'
        from /tmp/doc_repository/_ruby_libs/text_rendering.rb:96:in `get_md_rst_txt'
        from /tmp/doc_repository/_plugins/rosindex_generator.rb:38:in `get_readme'
        from /tmp/doc_repository/_plugins/rosindex_generator.rb:475:in `scrape_version'
        from /tmp/doc_repository/_plugins/rosindex_generator.rb:570:in `block in scrape_repo'
        from /tmp/doc_repository/_plugins/rosindex_generator.rb:539:in `each'
        from /tmp/doc_repository/_plugins/rosindex_generator.rb:539:in `scrape_repo'
        from /tmp/doc_repository/_plugins/rosindex_generator.rb:1207:in `block in generate'
        from /tmp/doc_repository/_plugins/rosindex_generator.rb:1201:in `each'
        from /tmp/doc_repository/_plugins/rosindex_generator.rb:1201:in `generate'
        from /home/jenkins-agent/.bundle/gems/jekyll-3.8.4/lib/jekyll/site.rb:175:in `block in generate'
        from /home/jenkins-agent/.bundle/gems/jekyll-3.8.4/lib/jekyll/site.rb:173:in `each'
        from /home/jenkins-agent/.bundle/gems/jekyll-3.8.4/lib/jekyll/site.rb:173:in `generate'
        from /home/jenkins-agent/.bundle/gems/jekyll-3.8.4/lib/jekyll/site.rb:70:in `process'
        from /home/jenkins-agent/.bundle/gems/jekyll-3.8.4/lib/jekyll/command.rb:28:in `process_site'
        from /home/jenkins-agent/.bundle/gems/jekyll-3.8.4/lib/jekyll/commands/build.rb:65:in `build'
        from /home/jenkins-agent/.bundle/gems/jekyll-3.8.4/lib/jekyll/commands/build.rb:36:in `process'
        from /home/jenkins-agent/.bundle/gems/jekyll-3.8.4/lib/jekyll/commands/build.rb:18:in `block (2 levels) in init_with_program'
        from /home/jenkins-agent/.bundle/gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `block in execute'
        from /home/jenkins-agent/.bundle/gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `each'
        from /home/jenkins-agent/.bundle/gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `execute'
        from /home/jenkins-agent/.bundle/gems/mercenary-0.3.6/lib/mercenary/program.rb:42:in `go'
        from /home/jenkins-agent/.bundle/gems/mercenary-0.3.6/lib/mercenary.rb:19:in `program'
        from /home/jenkins-agent/.bundle/gems/jekyll-3.8.4/exe/jekyll:15:in `<top (required)>'
        from /home/jenkins-agent/.bundle/bin/jekyll:23:in `load'
        from /home/jenkins-agent/.bundle/bin/jekyll:23:in `<main>'
    make: *** [build] Error 1
    Makefile:19: recipe for target 'build' failed
```

as seen on http://build.ros.org/job/doc_rosindex/78/console

The safe navigation operator could also be used but this is a bit
quicker for most people to grok and doesn't require us to invert the
conditional.

Pending approval and merge we should trigger a job immediately to make sure this is sufficient for the entire dataset. I mused on building it locally but it made sense that if it works we ought not waste the build time by not deploying it.