### PR TITLE
Fix sorting of repos and packages per distro

### DIFF
--- a/_layouts/packages.html
+++ b/_layouts/packages.html
@@ -72,64 +72,60 @@ layout: default
                 </tr>
               </thead>
               <tbody>
-              {% for packages_per_repo in page.list %}
-                {% if packages_per_repo[0] == distro %}
-                  {% for package in packages_per_repo[1] %}
-                    {% assign r = package[1].repos[distro].snapshots[distro] %}
-                    {% assign p = package[1].snapshots[distro] %}
-                    {% assign n_instances = package[1].instances | size %}
-                    <tr>
-                      <td title="View Package Instances" data-toggle="tooltip" data-placement="left" align="center">
-                        <a href="{{site.baseurl}}/packages/{{package[0]}}" class="label label-{% if n_instances > 1 %}primary{% else %}default{% endif %}">
-                            {{n_instances}}
-                        </a>
+              {% for package in page.list[distro] %}
+                {% assign r = package[1].repos[distro].snapshots[distro] %}
+                {% assign p = package[1].snapshots[distro] %}
+                {% assign n_instances = package[1].instances | size %}
+                <tr>
+                  <td title="View Package Instances" data-toggle="tooltip" data-placement="left" align="center">
+                    <a href="{{site.baseurl}}/packages/{{package[0]}}" class="label label-{% if n_instances > 1 %}primary{% else %}default{% endif %}">
+                        {{n_instances}}
+                    </a>
+                  </td>
+                  {% if p %}
+                    {% if r.released %}
+                      <td class="text-center">
+                        <span title="Released in {{distro}}" data-toggle="tooltip" data-placement="left" class="glyphicon glyphicon-flash"></span>
                       </td>
-                      {% if p %}
-                        {% if r.released %}
-                          <td class="text-center">
-                            <span title="Released in {{distro}}" data-toggle="tooltip" data-placement="left" class="glyphicon glyphicon-flash"></span>
-                          </td>
-                        {% else %}
-                          <td title="Not released in {{distro}}" data-toggle="tooltip" data-placement="left" class="text-center">
-                            <span class="glyphicon glyphicon-none"></span>
-                          </td>
-                        {% endif %}
-                        {% assign n_readmes = p.data[1].readmes | size %}
-                        {% if n_readmes > 0 %}
-                          <td title="Has README" data-toggle="tooltip" data-placement="left" align="center">
-                            <span class="glyphicon glyphicon-file"></span>
-                          </td>
-                        {% else %}
-                          <td title="No README" data-toggle="tooltip" data-placement="left" align="center">
-                            <span class="glyphicon glyphicon-none"></span>
-                          </td>
-                        {% endif %}
-                        </td>
-                        <td>
-                          <span title="Last commit date" class="label label-default">{{ r.data.last_commit_time }}</span>
-                        </td>
-                        <td>
-                          <a href="{{site.baseurl}}/p/{{package[0]}}">{{ package[0] }}</a>
-                        </td>
-                        <td>
-                          <div class="truncate">
-                            <div class="spacer">{{ p.data.description }}</div>
-                            <div class="content">{{ p.data.description }}</div>
-                            <span>&nbsp;</span>
-                          </div>
-                        </td>
-                      {% else %}
-                        <td></td>
-                        <td></td>
-                        <td></td>
-                        <td>
-                          <a class="inactive" href="{{site.baseurl}}/p/{{package[0]}}">{{ package[0] }}</a>
-                        </td>
-                        <td></td>
-                      {% endif %}
-                      </tr>
-                    {% endfor %}
+                    {% else %}
+                      <td title="Not released in {{distro}}" data-toggle="tooltip" data-placement="left" class="text-center">
+                        <span class="glyphicon glyphicon-none"></span>
+                      </td>
+                    {% endif %}
+                    {% assign n_readmes = p.data[1].readmes | size %}
+                    {% if n_readmes > 0 %}
+                      <td title="Has README" data-toggle="tooltip" data-placement="left" align="center">
+                        <span class="glyphicon glyphicon-file"></span>
+                      </td>
+                    {% else %}
+                      <td title="No README" data-toggle="tooltip" data-placement="left" align="center">
+                        <span class="glyphicon glyphicon-none"></span>
+                      </td>
+                    {% endif %}
+                    </td>
+                    <td>
+                      <span title="Last commit date" class="label label-default">{{ r.data.last_commit_time }}</span>
+                    </td>
+                    <td>
+                      <a href="{{site.baseurl}}/p/{{package[0]}}">{{ package[0] }}</a>
+                    </td>
+                    <td>
+                      <div class="truncate">
+                        <div class="spacer">{{ p.data.description }}</div>
+                        <div class="content">{{ p.data.description }}</div>
+                        <span>&nbsp;</span>
+                      </div>
+                    </td>
+                  {% else %}
+                    <td></td>
+                    <td></td>
+                    <td></td>
+                    <td>
+                      <a class="inactive" href="{{site.baseurl}}/p/{{package[0]}}">{{ package[0] }}</a>
+                    </td>
+                    <td></td>
                   {% endif %}
+                </tr>
               {% endfor %}
               </tbody>
             </table>

--- a/_layouts/packages.html
+++ b/_layouts/packages.html
@@ -94,7 +94,7 @@ layout: default
                             <span class="glyphicon glyphicon-none"></span>
                           </td>
                         {% endif %}
-                        {% n_readmes = p.data[1].readmes | size %}
+                        {% assign n_readmes = p.data[1].readmes | size %}
                         {% if n_readmes > 0 %}
                           <td title="Has README" data-toggle="tooltip" data-placement="left" align="center">
                             <span class="glyphicon glyphicon-file"></span>

--- a/_layouts/packages.html
+++ b/_layouts/packages.html
@@ -72,60 +72,65 @@ layout: default
                 </tr>
               </thead>
               <tbody>
-                {% for package in page.list %}
-                  {% assign r = package[1].repos[distro].snapshots[distro] %}
-                  {% assign p = package[1].snapshots[distro] %}
-                  {% assign n_instances = package[1].instances | size %}
-                  <tr>
-                    <td title="View Package Instances" data-toggle="tooltip" data-placement="left" align="center">
-                      <a href="{{site.baseurl}}/packages/{{package[0]}}" class="label label-{% if n_instances > 1 %}primary{% else %}default{% endif %}">
-                          {{n_instances}}
-                      </a>
-                    </td>
-                    {% if p %}
-                      {% if r.released %}
-                        <td class="text-center">
-                          <span title="Released in {{distro}}" data-toggle="tooltip" data-placement="left" class="glyphicon glyphicon-flash"></span>
+              {% for packages_per_repo in page.list %}
+                {% if packages_per_repo[0] == distro %}
+                  {% for package in packages_per_repo[1] %}
+                    {% assign r = package[1].repos[distro].snapshots[distro] %}
+                    {% assign p = package[1].snapshots[distro] %}
+                    {% assign n_instances = package[1].instances | size %}
+                    <tr>
+                      <td title="View Package Instances" data-toggle="tooltip" data-placement="left" align="center">
+                        <a href="{{site.baseurl}}/packages/{{package[0]}}" class="label label-{% if n_instances > 1 %}primary{% else %}default{% endif %}">
+                            {{n_instances}}
+                        </a>
+                      </td>
+                      {% if p %}
+                        {% if r.released %}
+                          <td class="text-center">
+                            <span title="Released in {{distro}}" data-toggle="tooltip" data-placement="left" class="glyphicon glyphicon-flash"></span>
+                          </td>
+                        {% else %}
+                          <td title="Not released in {{distro}}" data-toggle="tooltip" data-placement="left" class="text-center">
+                            <span class="glyphicon glyphicon-none"></span>
+                          </td>
+                        {% endif %}
+                        {% n_readmes = p.data[1].readmes | size %}
+                        {% if n_readmes > 0 %}
+                          <td title="Has README" data-toggle="tooltip" data-placement="left" align="center">
+                            <span class="glyphicon glyphicon-file"></span>
+                          </td>
+                        {% else %}
+                          <td title="No README" data-toggle="tooltip" data-placement="left" align="center">
+                            <span class="glyphicon glyphicon-none"></span>
+                          </td>
+                        {% endif %}
+                        </td>
+                        <td>
+                          <span title="Last commit date" class="label label-default">{{ r.data.last_commit_time }}</span>
+                        </td>
+                        <td>
+                          <a href="{{site.baseurl}}/p/{{package[0]}}">{{ package[0] }}</a>
+                        </td>
+                        <td>
+                          <div class="truncate">
+                            <div class="spacer">{{ p.data.description }}</div>
+                            <div class="content">{{ p.data.description }}</div>
+                            <span>&nbsp;</span>
+                          </div>
                         </td>
                       {% else %}
-                        <td title="Not released in {{distro}}" data-toggle="tooltip" data-placement="left" class="text-center">
-                          <span class="glyphicon glyphicon-none"></span>
+                        <td></td>
+                        <td></td>
+                        <td></td>
+                        <td>
+                          <a class="inactive" href="{{site.baseurl}}/p/{{package[0]}}">{{ package[0] }}</a>
                         </td>
+                        <td></td>
                       {% endif %}
-                      {% if p.data.readme %}
-                        <td title="Has README" data-toggle="tooltip" data-placement="left" align="center">
-                          <span class="glyphicon glyphicon-file"></span>
-                        </td>
-                      {% else %}
-                        <td title="No README" data-toggle="tooltip" data-placement="left" align="center">
-                          <span class="glyphicon glyphicon-none"></span>
-                        </td>
-                      {% endif %}
-                      </td>
-                      <td>
-                        <span title="Last commit date" class="label label-default">{{ r.data.last_commit_time }}</span>
-                      </td>
-                      <td>
-                        <a href="{{site.baseurl}}/p/{{package[0]}}">{{ package[0] }}</a>
-                      </td>
-                      <td>
-                        <div class="truncate">
-                          <div class="spacer">{{ p.data.description }}</div>
-                          <div class="content">{{ p.data.description }}</div>
-                          <span>&nbsp;</span>
-                        </div>
-                      </td>
-                    {% else %}
-                      <td></td>
-                      <td></td>
-                      <td></td>
-                      <td>
-                        <a class="inactive" href="{{site.baseurl}}/p/{{package[0]}}">{{ package[0] }}</a>
-                      </td>
-                      <td></td>
-                    {% endif %}
-                  </tr>
-                {% endfor %}
+                      </tr>
+                    {% endfor %}
+                  {% endif %}
+              {% endfor %}
               </tbody>
             </table>
           </div>

--- a/_layouts/repos.html
+++ b/_layouts/repos.html
@@ -70,58 +70,62 @@ layout: default
                 </tr>
               </thead>
               <tbody>
-              {% for repo in page.list %}
-                {% assign instance = repo[1].default %}
-                {% assign n_instances = repo[1].instances | size %}
-                <tr>
-                  <td data-toggle="tooltip" data-placement="left" title="View Repo Instances" align="center">
-                    <a href="{{site.baseurl}}/repos/{{repo[0]}}"class="label label-{% if n_instances > 1 %}primary{% else %}default{% endif %}">
-                        {{n_instances}}
-                    </a>
-                  </td>
-                  {% assign r = instance.snapshots[distro] %}
-                  {% if r.version %}
-                    {% if r.released %}
-                      <td class="text-center">
-                        <span title="Released in {{distro}}" data-toggle="tooltip" data-placement="left" class="glyphicon glyphicon-flash"></span>
+              {% for repos_per_distro in page.list %}
+                {% if repos_per_distro[0] == distro %}
+                  {% for repo in repos_per_distro[1] %}
+                    {% assign instance = repo[1].default %}
+                    {% assign n_instances = repo[1].instances | size %}
+                    <tr>
+                      <td data-toggle="tooltip" data-placement="left" title="View Repo Instances" align="center">
+                        <a href="{{site.baseurl}}/repos/{{repo[0]}}"class="label label-{% if n_instances > 1 %}primary{% else %}default{% endif %}">
+                            {{n_instances}}
+                        </a>
                       </td>
-                    {% else %}
-                      <td title="Not released in {{distro}}" data-toggle="tooltip" data-placement="left" class="text-center">
-                        <span class="glyphicon glyphicon-none"></span>
-                      </td>
-                    {% endif %}
-                    {% if r.data.readme %}
-                      <td title="Has README" data-toggle="tooltip" data-placement="left" align="center">
-                        <span class="glyphicon glyphicon-file"></span>
-                      </td>
-                    {% else %}
-                      <td title="No README" data-toggle="tooltip" data-placement="left" align="center">
-                        <span class="glyphicon glyphicon-none"></span>
-                      </td>
-                    {% endif %}
-                    <td>
-                      {% assign date_str = r.data.last_commit_time %}
-                      <span class="label label-default">{{ date_str }}</span>
-                    </td>
-                    <td>
-                      <a href="{{site.baseurl}}/r/{{repo[0]}}">{{ repo[0] }}</a>
-                    </td>
-                    <td>
-                      {% for p in r.packages %}
-                        {% assign labeled_package = p[1] %}
-                        <a href="{{site.baseurl}}/p/{{p[0]}}/{{default}}" class="label label-primary pkg-label">{% include peer_label.html %}</a>
-                      {% endfor %}
-                    </td>
-                  {% else %}
-                    <td></td>
-                    <td></td>
-                    <td></td>
-                    <td>
-                      <a class="inactive" href="{{site.baseurl}}/r/{{repo[0]}}">{{ repo[0] }}</a>
-                    </td>
-                    <td></td>
-                  {% endif %}
-                </tr>
+                      {% assign r = instance.snapshots[distro] %}
+                      {% if r.version %}
+                        {% if r.released %}
+                          <td class="text-center">
+                            <span title="Released in {{distro}}" data-toggle="tooltip" data-placement="left" class="glyphicon glyphicon-flash"></span>
+                          </td>
+                        {% else %}
+                          <td title="Not released in {{distro}}" data-toggle="tooltip" data-placement="left" class="text-center">
+                            <span class="glyphicon glyphicon-none"></span>
+                          </td>
+                        {% endif %}
+                        {% if r.data.readme %}
+                          <td title="Has README" data-toggle="tooltip" data-placement="left" align="center">
+                            <span class="glyphicon glyphicon-file"></span>
+                          </td>
+                        {% else %}
+                          <td title="No README" data-toggle="tooltip" data-placement="left" align="center">
+                            <span class="glyphicon glyphicon-none"></span>
+                          </td>
+                        {% endif %}
+                        <td>
+                          {% assign date_str = r.data.last_commit_time %}
+                          <span class="label label-default">{{ date_str }}</span>
+                        </td>
+                        <td>
+                          <a href="{{site.baseurl}}/r/{{repo[0]}}">{{ repo[0] }}</a>
+                        </td>
+                        <td>
+                          {% for p in r.packages %}
+                            {% assign labeled_package = p[1] %}
+                            <a href="{{site.baseurl}}/p/{{p[0]}}/{{default}}" class="label label-primary pkg-label">{% include peer_label.html %}</a>
+                          {% endfor %}
+                        </td>
+                      {% else %}
+                        <td></td>
+                        <td></td>
+                        <td></td>
+                        <td>
+                          <a class="inactive" href="{{site.baseurl}}/r/{{repo[0]}}">{{ repo[0] }}</a>
+                        </td>
+                        <td></td>
+                      {% endif %}
+                    </tr>
+                  {% endfor %}
+                {% endif %}
               {% endfor %}
               </tbody>
             </table>

--- a/_layouts/repos.html
+++ b/_layouts/repos.html
@@ -70,62 +70,58 @@ layout: default
                 </tr>
               </thead>
               <tbody>
-              {% for repos_per_distro in page.list %}
-                {% if repos_per_distro[0] == distro %}
-                  {% for repo in repos_per_distro[1] %}
-                    {% assign instance = repo[1].default %}
-                    {% assign n_instances = repo[1].instances | size %}
-                    <tr>
-                      <td data-toggle="tooltip" data-placement="left" title="View Repo Instances" align="center">
-                        <a href="{{site.baseurl}}/repos/{{repo[0]}}"class="label label-{% if n_instances > 1 %}primary{% else %}default{% endif %}">
-                            {{n_instances}}
-                        </a>
+              {% for repo in page.list[distro] %}
+                {% assign instance = repo[1].default %}
+                {% assign n_instances = repo[1].instances | size %}
+                <tr>
+                  <td data-toggle="tooltip" data-placement="left" title="View Repo Instances" align="center">
+                    <a href="{{site.baseurl}}/repos/{{repo[0]}}"class="label label-{% if n_instances > 1 %}primary{% else %}default{% endif %}">
+                        {{n_instances}}
+                    </a>
+                  </td>
+                  {% assign r = instance.snapshots[distro] %}
+                  {% if r.version %}
+                    {% if r.released %}
+                      <td class="text-center">
+                        <span title="Released in {{distro}}" data-toggle="tooltip" data-placement="left" class="glyphicon glyphicon-flash"></span>
                       </td>
-                      {% assign r = instance.snapshots[distro] %}
-                      {% if r.version %}
-                        {% if r.released %}
-                          <td class="text-center">
-                            <span title="Released in {{distro}}" data-toggle="tooltip" data-placement="left" class="glyphicon glyphicon-flash"></span>
-                          </td>
-                        {% else %}
-                          <td title="Not released in {{distro}}" data-toggle="tooltip" data-placement="left" class="text-center">
-                            <span class="glyphicon glyphicon-none"></span>
-                          </td>
-                        {% endif %}
-                        {% if r.data.readme %}
-                          <td title="Has README" data-toggle="tooltip" data-placement="left" align="center">
-                            <span class="glyphicon glyphicon-file"></span>
-                          </td>
-                        {% else %}
-                          <td title="No README" data-toggle="tooltip" data-placement="left" align="center">
-                            <span class="glyphicon glyphicon-none"></span>
-                          </td>
-                        {% endif %}
-                        <td>
-                          {% assign date_str = r.data.last_commit_time %}
-                          <span class="label label-default">{{ date_str }}</span>
-                        </td>
-                        <td>
-                          <a href="{{site.baseurl}}/r/{{repo[0]}}">{{ repo[0] }}</a>
-                        </td>
-                        <td>
-                          {% for p in r.packages %}
-                            {% assign labeled_package = p[1] %}
-                            <a href="{{site.baseurl}}/p/{{p[0]}}/{{default}}" class="label label-primary pkg-label">{% include peer_label.html %}</a>
-                          {% endfor %}
-                        </td>
-                      {% else %}
-                        <td></td>
-                        <td></td>
-                        <td></td>
-                        <td>
-                          <a class="inactive" href="{{site.baseurl}}/r/{{repo[0]}}">{{ repo[0] }}</a>
-                        </td>
-                        <td></td>
-                      {% endif %}
-                    </tr>
-                  {% endfor %}
-                {% endif %}
+                    {% else %}
+                      <td title="Not released in {{distro}}" data-toggle="tooltip" data-placement="left" class="text-center">
+                        <span class="glyphicon glyphicon-none"></span>
+                      </td>
+                    {% endif %}
+                    {% if r.data.readme %}
+                      <td title="Has README" data-toggle="tooltip" data-placement="left" align="center">
+                        <span class="glyphicon glyphicon-file"></span>
+                      </td>
+                    {% else %}
+                      <td title="No README" data-toggle="tooltip" data-placement="left" align="center">
+                        <span class="glyphicon glyphicon-none"></span>
+                      </td>
+                    {% endif %}
+                    <td>
+                      {% assign date_str = r.data.last_commit_time %}
+                      <span class="label label-default">{{ date_str }}</span>
+                    </td>
+                    <td>
+                      <a href="{{site.baseurl}}/r/{{repo[0]}}">{{ repo[0] }}</a>
+                    </td>
+                    <td>
+                      {% for p in r.packages %}
+                        {% assign labeled_package = p[1] %}
+                        <a href="{{site.baseurl}}/p/{{p[0]}}/{{default}}" class="label label-primary pkg-label">{% include peer_label.html %}</a>
+                      {% endfor %}
+                    </td>
+                  {% else %}
+                    <td></td>
+                    <td></td>
+                    <td></td>
+                    <td>
+                      <a class="inactive" href="{{site.baseurl}}/r/{{repo[0]}}">{{ repo[0] }}</a>
+                    </td>
+                    <td></td>
+                  {% endif %}
+                </tr>
               {% endfor %}
               </tbody>
             </table>

--- a/_layouts/system_deps.html
+++ b/_layouts/system_deps.html
@@ -40,7 +40,7 @@ layout: default
                 </tr>
               </thead>
               <tbody>
-                {% for dep in page.list %}
+                {% for dep in page.list[distro] %}
                   {% assign dep_name = dep[0] %}
                   {% assign dep_details = dep[1] %}
                   <tr>

--- a/_plugins/rosindex_generator.rb
+++ b/_plugins/rosindex_generator.rb
@@ -656,9 +656,13 @@ class Indexer < Jekyll::Generator
 
       elements_sorted.each do |sort_key, elements|
         # Get a subset of the elements
-        elements_sliced = Hash.new
-        elements.each do |distro, items|
-          elements_sliced[distro] = items.slice(p_start, elements_per_page)
+        unless sort_key == 'name' then
+          elements_sliced = Hash.new
+          elements.each do |distro, items|
+            elements_sliced[distro] = items.slice(p_start, elements_per_page)
+          end
+        else
+          elements_sliced = elements.slice(p_start, elements_per_page)
         end
         site.pages << page_class.new( site, sort_key, n_pages, page_index, elements_sliced)
         # create page 1 without a page number or key in the url
@@ -690,7 +694,7 @@ class Indexer < Jekyll::Generator
         -(instances.default.snapshots.count { |d,s|
           $recent_distros.include?(d) and not s.data['readmes'].nil? or not d == distro
         })
-      }
+      }.reverse
     end
 
     repos_sorted['released'] = Hash.new
@@ -723,11 +727,11 @@ class Indexer < Jekyll::Generator
 
     packages_sorted['doc'] = Hash.new
     $all_distros.each do |distro|
-      packages_sorted['doc'][distro] = packages_sorted['name'].sort_by { |name, instances|
+      packages_sorted['doc'][distro] = packages_sorted['name'].reverse.sort_by { |name, instances|
         -(instances.snapshots.count { |d,s|
           not s.nil? and $recent_distros.include?(d) and not s.data['readmes'].count > 0 or not distro == d
         })
-      }
+      }.reverse
     end
 
     packages_sorted['released'] = Hash.new

--- a/_plugins/rosindex_generator.rb
+++ b/_plugins/rosindex_generator.rb
@@ -468,7 +468,6 @@ class Indexer < Jekyll::Generator
       'browse_uri' => get_browse_uri(repo.uri, repo.type, snapshot.version),
       # get the date of the last modification
       'last_commit_time' => vcs.get_last_commit_time(),
-
       'readme' => nil,
       'readme_rendered' => nil}
 
@@ -652,106 +651,94 @@ class Indexer < Jekyll::Generator
     (1..n_pages).each do |page_index|
 
       p_start = (page_index-1) * elements_per_page
-      p_end = [n_elements, p_start+elements_per_page].min
 
       elements_sorted.each do |sort_key, elements|
         # Get a subset of the elements
-        unless sort_key == 'name' then
-          elements_sliced = Hash.new
-          elements.each do |distro, items|
-            elements_sliced[distro] = items.slice(p_start, elements_per_page)
+        elements_sliced = Hash[
+          elements.collect do |distro, elements_in_distro|
+            [distro, elements_in_distro.slice(p_start, elements_per_page)]
           end
-        else
-          elements_sliced = elements.slice(p_start, elements_per_page)
-        end
-        site.pages << page_class.new( site, sort_key, n_pages, page_index, elements_sliced)
+        ]
+        site.pages << page_class.new(site, sort_key, n_pages, page_index, elements_sliced)
         # create page 1 without a page number or key in the url
         if sort_key == default_sort_key and page_index == 1
-          site.pages << page_class.new( site, sort_key, n_pages, page_index, elements_sliced, true)
+          site.pages << page_class.new(site, sort_key, n_pages, page_index, elements_sliced, true)
         end
       end
     end
   end
 
   def sort_repos(site)
-    repos_sorted = {}
-    repos_sorted['name']= @repo_names.sort_by { |name, instances| name }
+    repos_sorted = {'name' => {}, 'time' => {}, 'doc' => {}, 'released' => {}}
 
-    repos_sorted['time'] = Hash.new
-    $all_distros.each do |distro|
-      repos_sorted['time'][distro] = repos_sorted['name'].reverse.sort_by { |name, instances|
-        instances.default.snapshots.reject { |d,s|
-          s.nil? or not $recent_distros.include?(d) or not distro == d
-        }.map { |d,s|
+    repos_sorted_by_name = @repo_names.sort_by { |name, _| name }
+    $all_distros.collect do |distro|
+      repos_sorted['name'][distro] = repos_sorted_by_name
+
+      repos_sorted['time'][distro] = \
+      repos_sorted['name'][distro].sort_by do |_, instances|
+        instances.default.snapshots.select do |d, s|
+          distro == d and not s.nil?
+        end.map do |d,s|
           s.data['last_commit_time'].to_s
-        }.max.to_s
-      }.reverse
-    end
+        end.max.to_s
+      end.reverse
 
-    repos_sorted['doc'] = Hash.new
-    $all_distros.each do |distro|
-      repos_sorted['doc'][distro] = repos_sorted['name'].reverse.sort_by { |name, instances|
-        -(instances.default.snapshots.count { |d,s|
-          $recent_distros.include?(d) and not s.data['readmes'].nil? or not d == distro
-        })
-      }.reverse
-    end
+      repos_sorted['doc'][distro] = \
+      repos_sorted['name'][distro].sort_by do |_, instances|
+        instances.default.snapshots.count do |d, s|
+          d == distro and not s.nil? and not s.data['readme'].nil?
+        end
+      end.reverse
 
-    repos_sorted['released'] = Hash.new
-    $all_distros.each do |distro|
-      repos_sorted['released'][distro] = repos_sorted['name'].reverse.sort_by { |name, instances|
-      -(instances.default.snapshots.count { |d,s|
-        $recent_distros.include?(d) and not s.released or not d == distro
-      })
-    }
+      repos_sorted['released'][distro] = \
+      repos_sorted['name'][distro].sort_by do |_, instances|
+        instances.default.snapshots.count do |d, s|
+          d == distro and not s.nil? and s.released
+        end
+      end.reverse
     end
 
     return repos_sorted
   end
 
   def sort_packages(site)
-    packages_sorted = {}
+    packages_sorted = {'name' => {}, 'time' => {}, 'doc' => {}, 'released' => {}}
 
-    packages_sorted['name'] = @package_names.sort_by { |name, instances| name }
-
-    packages_sorted['time'] = Hash.new
+    packages_sorted_by_name = @package_names.sort_by { |name, _| name }
     $all_distros.each do |distro|
-      packages_sorted['time'][distro] = packages_sorted['name'].reverse.sort_by { |name, instances|
-        instances.snapshots.reject { |d,s|
-          s.nil? or not $recent_distros.include?(d) or not distro == d
-        }.map { |d,s|
+      packages_sorted['name'][distro] = packages_sorted_by_name
+
+      packages_sorted['time'][distro] = \
+      packages_sorted['name'][distro].sort_by do |_, instances|
+        instances.snapshots.select do |d, s|
+          distro == d and not s.nil?
+        end.map do |_, s|
           s.snapshot.data['last_commit_time'].to_s
-        }.max.to_s
-      }.reverse
-    end
+        end.max.to_s
+      end.reverse
 
-    packages_sorted['doc'] = Hash.new
-    $all_distros.each do |distro|
-      packages_sorted['doc'][distro] = packages_sorted['name'].reverse.sort_by { |name, instances|
-        -(instances.snapshots.count { |d,s|
-          not s.nil? and $recent_distros.include?(d) and not s.data['readmes'].count > 0 or not distro == d
-        })
-      }.reverse
-    end
+      packages_sorted['doc'][distro] = \
+      packages_sorted['name'][distro].sort_by do |_, instances|
+        instances.snapshots.count do |d, s|
+          distro == d and not s.nil? and s.data['readmes'].count > 0
+        end
+      end.reverse
 
-    packages_sorted['released'] = Hash.new
-    $all_distros.each do |distro|
-      packages_sorted['released'][distro] = packages_sorted['name'].reverse.sort_by { |name, instances|
-        -(instances.snapshots.count { |d,s|
-          $recent_distros.include?(d) and not s.nil? and s.snapshot.released or not distro == d
-        })
-      }
+      packages_sorted['released'][distro] = \
+      packages_sorted['name'][distro].sort_by do |_, instances|
+        instances.snapshots.count do |d, s|
+          distro == d and not s.nil? and s.snapshot.released
+        end
+      end.reverse
     end
 
     return packages_sorted
   end
 
   def sort_rosdeps(site)
-    rosdeps_sorted = {}
-
-    rosdeps_sorted['name'] = @rosdeps.sort_by { |name, details| name }
-
-    return rosdeps_sorted
+    sorted_rosdeps = @rosdeps.sort_by { |name, _| name }
+    return {'name' => Hash[$all_distros.collect {|distro| [distro, sorted_rosdeps]}] }
   end
 
   def write_release_manifests(site, repo, package_name, default)


### PR DESCRIPTION
Closes https://github.com/ros-infrastructure/rosindex/issues/96
This PR:
- Fixes the sorting of both packages and repos by last commit date, as originally requested in the ticket
- Also fixes the sorting "by release" and "by documentation"

The sorting mechanism was using a single list across all the available distros, so the date shown in the date column corresponded the most recently modified version of a package whereas the sorting criteria was using the date from the commit date of the package released for a particular distro.

~~Pending:~~
~~- The sorting "by documentation" for packages is still not working.~~

To consider:
- I've found that this sorting mechanism is hardcoded to work only with recent distros, leading the packages/repos from older deprecated distros unsorted. Is this intended?