### PR TITLE
Update Pandoc version to get RST tables support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,20 +5,20 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     awesome_print (1.8.0)
     colorator (1.1.0)
-    concurrent-ruby (1.0.5)
+    concurrent-ruby (1.1.4)
     em-websocket (0.5.1)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
     ethon (0.11.0)
       ffi (>= 1.3.0)
     eventmachine (1.2.7)
-    ffi (1.9.25)
+    ffi (1.10.0)
     forwardable-extended (2.6.0)
-    github-markup (2.0.1)
+    github-markup (3.0.2)
     http_parser.rb (0.6.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
-    jekyll (3.8.4)
+    jekyll (3.8.5)
       addressable (~> 2.4)
       colorator (~> 1.0)
       em-websocket (~> 0.5)
@@ -31,19 +31,11 @@ GEM
       pathutil (~> 0.9)
       rouge (>= 1.7, < 4)
       safe_yaml (~> 1.0)
-    jekyll-optional-front-matter (0.3.0)
-      jekyll (~> 3.0)
-    jekyll-readme-index (0.2.0)
-      jekyll (~> 3.0)
-    jekyll-relative-links (0.5.3)
-      jekyll (~> 3.3)
     jekyll-sass-converter (1.5.2)
       sass (~> 3.4)
     jekyll-sitemap (1.2.0)
       jekyll (~> 3.3)
-    jekyll-titles-from-headings (0.5.1)
-      jekyll (~> 3.3)
-    jekyll-watch (2.1.1)
+    jekyll-watch (2.1.2)
       listen (~> 3.0)
     kramdown (1.17.0)
     liquid (4.0.1)
@@ -54,31 +46,31 @@ GEM
     mercenary (0.3.6)
     mercurial-ruby (0.7.12)
       open4 (~> 1.3.0)
-    mini_portile2 (2.3.0)
+    mini_portile2 (2.4.0)
     multi_json (1.13.1)
-    nokogiri (1.8.5)
-      mini_portile2 (~> 2.3.0)
+    nokogiri (1.10.0)
+      mini_portile2 (~> 2.4.0)
     open4 (1.3.4)
     pandoc-ruby (2.0.2)
-    pathutil (0.16.1)
+    pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (3.0.3)
     pygments.rb (1.2.1)
       multi_json (>= 1.0.0)
     rb-fsevent (0.10.3)
-    rb-inotify (0.9.10)
-      ffi (>= 0.5.0, < 2)
+    rb-inotify (0.10.0)
+      ffi (~> 1.0)
     redcarpet (3.4.0)
     rouge (3.3.0)
     ruby_dep (1.5.0)
-    rugged (0.27.5)
+    rugged (0.27.7)
     safe_yaml (1.0.4)
-    sass (3.6.0)
+    sass (3.7.3)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
-    typhoeus (1.3.0)
+    typhoeus (1.3.1)
       ethon (>= 0.9.0)
 
 PLATFORMS
@@ -89,11 +81,7 @@ DEPENDENCIES
   colorator
   github-markup
   jekyll
-  jekyll-optional-front-matter
-  jekyll-readme-index
-  jekyll-relative-links
   jekyll-sitemap
-  jekyll-titles-from-headings
   liquid
   mercurial-ruby
   nokogiri
@@ -104,4 +92,4 @@ DEPENDENCIES
   typhoeus
 
 BUNDLED WITH
-   1.16.2
+   2.0.1

--- a/docker/image/Dockerfile
+++ b/docker/image/Dockerfile
@@ -25,18 +25,22 @@ RUN apt-get update && \
         mercurial \
         nodejs \
         openssl \
-        pandoc \
         pkg-config \
         python-pip \
         python3-vcstool \
         ruby \
         ruby-dev \
-        rubygems-integration && \
+        rubygems-integration \
+        wget && \
     rm -rf /var/lib/apt/lists/*
 
 RUN gem install bundle
 RUN pip install --upgrade setuptools pip
 RUN pip install recommonmark==0.4 sphinx==1.5.6
+
+# Install pandoc
+RUN wget -nv https://github.com/jgm/pandoc/releases/download/2.5/pandoc-2.5-1-amd64.deb -O /tmp/pandoc.deb && \
+    dpkg -i /tmp/pandoc.deb
 
 RUN ln -s `which nodejs` /usr/local/bin/node
 

--- a/docker/image/Dockerfile
+++ b/docker/image/Dockerfile
@@ -1,13 +1,29 @@
-FROM ubuntu:xenial
+FROM ubuntu:bionic
 
 ARG user=rosindex
 ARG uid=1000
 
 ENV DEBIAN_FRONTEND noninteractive
 
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y \
+        gnupg && \
+    rm -rf /var/lib/apt/lists/*
+
 RUN echo "deb http://packages.ros.org/ros/ubuntu xenial main" > \
          /etc/apt/sources.list.d/ros-latest.list
 RUN apt-key adv --keyserver hkp://pool.sks-keyservers.net --recv-key 0xB01FA116
+
+RUN echo 'deb http://archive.ubuntu.com/ubuntu/ cosmic universe\n' >> \
+        /etc/apt/sources.list
+RUN echo 'Package: *\n\
+Pin: release n=cosmic\n\
+Pin-Priority: -10\n\
+\n\
+Package: pandoc*\n\
+Pin: release n=cosmic\n\
+Pin-Priority: 500\n\
+' > /etc/apt/preferences.d/cosmic.pref
 
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \
@@ -20,27 +36,22 @@ RUN apt-get update && \
         libgit2-dev \
         libpthread-stubs0-dev \
         libssl-dev \
-        libsslcommon2-dev \
         libz-dev \
         mercurial \
         nodejs \
         openssl \
+        pandoc \
         pkg-config \
         python-pip \
         python3-vcstool \
         ruby \
         ruby-dev \
-        rubygems-integration \
-        wget && \
+        rubygems-integration && \
     rm -rf /var/lib/apt/lists/*
 
 RUN gem install bundle
 RUN pip install --upgrade setuptools pip
 RUN pip install recommonmark==0.4 sphinx==1.5.6
-
-# Install pandoc
-RUN wget -nv https://github.com/jgm/pandoc/releases/download/2.5/pandoc-2.5-1-amd64.deb -O /tmp/pandoc.deb && \
-    dpkg -i /tmp/pandoc.deb
 
 RUN ln -s `which nodejs` /usr/local/bin/node
 


### PR DESCRIPTION
Fixes https://github.com/ros-infrastructure/rosindex/issues/111

- This PR updates the version of Pandoc from `1.16.0.2` (included in Ubuntu 16.04 by default) with the `2.5` release.
- This deb is downloaded via `wget` from Pandoc's official release page and installed via `dpkg`.
- There are no PPA available to install this package, and although it could be installed from Haskell's package manager `cabal`, installing Pandoc with this tool proved to be unreliable during our tests (a high failure rate due to poor availability of the dependencies).