### PR TITLE
Minimize git diff on upload

### DIFF
--- a/docker/image/Dockerfile
+++ b/docker/image/Dockerfile
@@ -43,6 +43,7 @@ RUN apt-get update && \
         pandoc \
         pkg-config \
         python-pip \
+        python3-pip \
         python3-vcstool \
         ruby \
         ruby-dev \
@@ -52,12 +53,15 @@ RUN apt-get update && \
 RUN gem install bundle
 RUN pip install --upgrade setuptools pip
 RUN pip install recommonmark==0.4 sphinx==1.5.6
+RUN pip3 install --upgrade pip
+RUN pip3 install gitpython
 
 RUN ln -s `which nodejs` /usr/local/bin/node
 
 COPY docker/image/build_site.sh /usr/local/bin/build_site
 COPY docker/image/test_site.sh /usr/local/bin/test_site
 COPY docker/image/update_site.sh /usr/local/bin/update_site
+COPY docker/image/git_add_files.py /usr/local/bin/git_add_files
 
 RUN useradd -u $uid -m $user
 ENV HOME=/home/$user

--- a/docker/image/git_add_files.py
+++ b/docker/image/git_add_files.py
@@ -9,7 +9,6 @@ def run(args):
     repo = git.Repo(args.repository_path)
 
     git_diff_numstat = repo.git.diff(numstat=True)
-    git_diff = repo.git.diff().encode("utf-8")
 
     # Parse information from git's numstat
     modified_files = {}
@@ -39,8 +38,10 @@ def run(args):
            change['blacklisted']:
             blacklisted_files.append(file)
 
-    # Remove blacklisted files from git
-    repo.git.reset(blacklisted_files)
+    if blacklisted_files:
+        # Remove blacklisted files from git
+        repo.index.reset(paths=blacklisted_files)
+        repo.git.checkout('.')
 
 
 if __name__ == "__main__":

--- a/docker/image/git_add_files.py
+++ b/docker/image/git_add_files.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+
+import argparse
+import git
+import re
+
+parser = argparse.ArgumentParser(
+    description='Add selected files to git repository.')
+parser.add_argument('repository_path', action='store')
+args = parser.parse_args()
+repo = git.Repo(args.repository_path)
+
+git_diff_numstat = repo.git.diff(numstat=True)
+git_diff = repo.git.diff().encode("utf-8")
+
+# Parse information from git's numstat
+modified_files = {}
+for line in git_diff_numstat.splitlines():
+    tmp = re.split(r'\t+', line)
+    modified_files[tmp[2]] = {}
+    modified_files[tmp[2]]["lines_added"] = int(tmp[0])
+    modified_files[tmp[2]]["lines_removed"] = int(tmp[1])
+
+# Filter files that have been modified and contain blacklisted strings
+diff_index = repo.index.diff(None)
+for diff_item in diff_index.iter_change_type('M'):
+    filename = diff_item.a_path
+    if filename in modified_files:
+        modified_files[filename]["blacklisted"] = "generated on" in diff_item.a_blob.data_stream.read(
+        ).decode('utf-8')
+
+# Add all files to git
+repo.git.add('--all')
+blacklisted_files = []
+
+# Classify modified files by blacklisted status
+for file, change in modified_files.items():
+    if change['lines_added'] == 1 and \
+       change['lines_removed'] == 1 and \
+       change['blacklisted']:
+        blacklisted_files.append(file)
+
+# Remove blacklisted files from git
+repo.git.reset(blacklisted_files)

--- a/docker/image/update_site.sh
+++ b/docker/image/update_site.sh
@@ -4,4 +4,4 @@ REPO_PATH=${1:-`pwd`}
 SITE_PATH=${2:-${REPO_PATH}/_site}
 build_site $REPO_PATH $SITE_PATH
 git_add_files $SITE_PATH
-git -C $SITE_PATH commit -a -m "ROSIndex deployment by `whoami`"
+git -C $SITE_PATH commit -m "ROSIndex deployment by `whoami`"

--- a/docker/image/update_site.sh
+++ b/docker/image/update_site.sh
@@ -3,5 +3,5 @@
 REPO_PATH=${1:-`pwd`}
 SITE_PATH=${2:-${REPO_PATH}/_site}
 build_site $REPO_PATH $SITE_PATH
-git -C $SITE_PATH add --all
+git_add_files $SITE_PATH
 git -C $SITE_PATH commit -a -m "ROSIndex deployment by `whoami`"


### PR DESCRIPTION
Closes https://github.com/ros-infrastructure/rosindex/issues/108

- This PR adds a python script that takes care of selecting which of the modified files deserve to be added to git to be committed.
- From the tests I run from a typical rosindex deploy scenario, the committed changes went down from a rough 22k files to about 1k :)
- In that scenario, the script took about 50 seconds to run on my machine (intel 8th gen @ ~3ghz)