### PR TITLE
ROS 2 rosdistro db has been merged into ros/rosdistro.

### DIFF
--- a/_data/remotes.yml
+++ b/_data/remotes.yml
@@ -6,8 +6,8 @@ repositories:
     version: master
   ros2_rosdistro:
     type: git
-    url: https://github.com/ros2/rosdistro.git
-    version: ros2
+    url: https://github.com/ros/rosdistro.git
+    version: master
   rosdep:
     type: git
     url: https://github.com/ros/rosdistro.git

--- a/_data/remotes.yml
+++ b/_data/remotes.yml
@@ -4,10 +4,6 @@ repositories:
     type: git
     url: https://github.com/ros/rosdistro.git
     version: master
-  ros2_rosdistro:
-    type: git
-    url: https://github.com/ros/rosdistro.git
-    version: master
   rosdep:
     type: git
     url: https://github.com/ros/rosdistro.git

--- a/index.yml
+++ b/index.yml
@@ -11,7 +11,7 @@ keep_files: [cache, .git]
 
 # Sources
 rosdep_path: _remotes/rosdep
-rosdistro_paths: [_remotes/rosdistro, _remotes/ros2_rosdistro]
+rosdistro_paths: [_remotes/rosdistro]
 repos_path: _remotes/rosforks/repos
 attic_file: _remotes/rosforks/attic.yaml
 


### PR DESCRIPTION
See https://github.com/ros2/rosdistro/issues/492

I believe this is sufficient for the next rosindex job to run correctly.
One concern I had was whether merging the index files would cause all
distros to be counted double, as both ROS 1 and ROS 2 distros, but since
the working list of individual distributions is stored in _config.yml
that shouldn't be a problem. All the same I'd be glad if someone from
the rosindex core maintainers could check my work.