### PR TITLE
Update the keyserver url to the ha servers

### DIFF
--- a/docker/image/Dockerfile
+++ b/docker/image/Dockerfile
@@ -12,7 +12,8 @@ RUN apt-get update && \
 
 RUN echo "deb http://packages.ros.org/ros/ubuntu xenial main" > \
          /etc/apt/sources.list.d/ros-latest.list
-RUN apt-key adv --keyserver hkp://pool.sks-keyservers.net --recv-key 0xB01FA116
+RUN sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 \
+         --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
 
 RUN echo 'deb http://archive.ubuntu.com/ubuntu/ cosmic universe\n' >> \
         /etc/apt/sources.list


### PR DESCRIPTION
As recommended at: http://wiki.ros.org/melodic/Installation/Ubuntu

This key fetching is failing 75% of the builds right now.