### PR TITLE
Collect documentation images too

### DIFF
--- a/_ruby_libs/pages.rb
+++ b/_ruby_libs/pages.rb
@@ -364,16 +364,11 @@ end
 class RelocatableStaticFile < Jekyll::StaticFile
   def initialize(site, base, dir, name, dest = nil)
     super(site, base, dir, name)
-    @dest = dest
+    @dest = dest || File.join(destination_rel_dir, @name)
   end
 
-  def destination(dest)
-    args = if not @dest
-             [dest, destination_rel_dir, @name]
-           else
-             [dest, @dest]
-           end
-    @site.in_dest_dir(*args.compact)
+  def destination(dest_root)
+    @site.in_dest_dir(*[dest_root, @dest].compact)
   end
 end
 

--- a/_ruby_libs/pages.rb
+++ b/_ruby_libs/pages.rb
@@ -180,7 +180,7 @@ class DocPage < Jekyll::Page
   def initialize(site, parent_page, path, data)
     @site = site
     @base = site.source
-    @dir  = "doc/#{path}"
+    @dir  = "#{path}"
     @name = "index.html"
     self.process(@name)
     self.data ||= {}
@@ -358,6 +358,22 @@ end
 class ReportFile < Jekyll::StaticFile
   def write(dest)
     true
+  end
+end
+
+class RelocatableStaticFile < Jekyll::StaticFile
+  def initialize(site, base, dir, name, dest = nil)
+    super(site, base, dir, name)
+    @dest = dest
+  end
+
+  def destination(dest)
+    args = if not @dest
+             [dest, destination_rel_dir, @name]
+           else
+             [dest, @dest]
+           end
+    @site.in_dest_dir(*args.compact)
   end
 end
 


### PR DESCRIPTION
This pull requests makes sure documentation images are collected too, not only .rst pages. Releases' page in ros2/ros2_documentation now renders as follows:

![working_images](https://user-images.githubusercontent.com/13500507/52587554-0ab1df00-2e19-11e9-9aa3-3ea31e8e11e9.png)

Builds on top of #141 to avoid rebases.