### PR TITLE
Migrates to python3.

### DIFF
--- a/_plugins/docs_generator.rb
+++ b/_plugins/docs_generator.rb
@@ -103,7 +103,7 @@ class DocPageGenerator < Jekyll::Generator
     output_path = Pathname.new(File.join(repo_path, '_build'))
     FileUtils.rm_r(output_path) if File.directory? output_path
     FileUtils.makedirs(output_path)
-    command = "sphinx-build -b json -c #{repo_path} #{input_path} #{output_path}"
+    command = "python3 -m sphinx -b json -c #{repo_path} #{input_path} #{output_path}"
     pid = Kernel.spawn(command)
     Process.wait pid
 

--- a/docker/image/Dockerfile
+++ b/docker/image/Dockerfile
@@ -43,7 +43,6 @@ RUN apt-get update && \
         openssl \
         pandoc \
         pkg-config \
-        python-pip \
         python3-pip \
         python3-vcstool \
         ruby \
@@ -52,10 +51,8 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 RUN gem install bundle
-RUN pip install --upgrade setuptools pip
-RUN pip install sphinx
-RUN pip3 install --upgrade pip
-RUN pip3 install gitpython
+RUN pip3 install --upgrade setuptools pip
+RUN pip3 install sphinx gitpython
 
 RUN ln -s `which nodejs` /usr/local/bin/node
 


### PR DESCRIPTION
This pull requests migrates Sphinx based documentation generation to `python3`.

Signed-off-by: Michel Hidalgo <michel@ekumenlabs.com>