### PR TITLE
Update Gemfile.lock to 2.0.2.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,4 +92,4 @@ DEPENDENCIES
   typhoeus
 
 BUNDLED WITH
-   2.0.1
+   2.0.2


### PR DESCRIPTION
The fact that patch versions result in breakages is kind of annoying.
It seems odious to pin the bundler version and to let the job start
breaking on every bundler patch release.

This will at least get us building until bundler 2.0.3 and we can decide
how best to handle this then.

Fixes #168.