### PR TITLE
Propagate files in _downloads directories to site

### DIFF
--- a/_plugins/docs_generator.rb
+++ b/_plugins/docs_generator.rb
@@ -51,7 +51,7 @@ class DocPageGenerator < Jekyll::Generator
 
         site.pages << document
       end
-      repo_build['images'].each do |permalink, path|
+      repo_build['static_files'].each do |permalink, path|
         site.static_files << RelocatableStaticFile.new(
           site, site.source,
           File.dirname(path), File.basename(path),
@@ -160,11 +160,11 @@ class DocPageGenerator < Jekyll::Generator
         first_depth <=> second_depth
       end
     end
-    Dir.glob(File.join(output_path, '_images/*.*'),
-             File::FNM_CASEFOLD).each do |image_path|
-      image_path = Pathname.new(image_path)
-      image_permalink = image_path.relative_path_from(output_path)
-      repo_build['images'][image_permalink] = image_path
+    Dir.glob(File.join(output_path, '{_images/*.*,_downloads/**/*.*}'),
+             File::FNM_CASEFOLD).each do |static_file_path|
+      static_file_path = Pathname.new(static_file_path)
+      static_file_permalink = static_file_path.relative_path_from(output_path)
+      repo_build['static_files'][static_file_permalink] = static_file_path
     end
     return repo_build
   end


### PR DESCRIPTION
Process static files in `_downloads` directories similarly to how we handle files in `_images` directories. Files end up in _downloads when they're referenced via the `:download:` directive in the input to Sphinx.

The important change is on L163. The rest is just renaming variables and keys to indicate that we're now handling static files that might not all be images.

I've tested this change locally following the instructions (https://github.com/ros-infrastructure/rosindex) and I get a working result. I can only hope that we'll see the same behavior on the farm.

Fixes #170.

E.g., if we have the following Sphinx-generated files:

$ find _remotes/ros2/_build/_downloads/
_remotes/ros2/_build/_downloads/
_remotes/ros2/_build/_downloads/97c67a555e198d8a224193fe961f770c
_remotes/ros2/_build/_downloads/97c67a555e198d8a224193fe961f770c/ros2-tsc-charter.pdf
_remotes/ros2/_build/_downloads/be940211da7b10813c678f8ee356f739
_remotes/ros2/_build/_downloads/be940211da7b10813c678f8ee356f739/ros2-brochure-ltr-print.pdf
_remotes/ros2/_build/_downloads/50f324bd6747229aa227cea87b196d82
_remotes/ros2/_build/_downloads/50f324bd6747229aa227cea87b196d82/ros2-brochure-a4-print.pdf
_remotes/ros2/_build/_downloads/8e95be988eb4e1795a9313b3ebc03875
_remotes/ros2/_build/_downloads/8e95be988eb4e1795a9313b3ebc03875/ros2-brochure-a4-web.pdf
_remotes/ros2/_build/_downloads/cab7bd9cff323a3b69ebb518707a1552
_remotes/ros2/_build/_downloads/cab7bd9cff323a3b69ebb518707a1552/ros2-brochure-ltr-web.pdf

Then with this change in place we'll see those files in the published site like
so:

$ find _site/doc/ros2/_downloads/
_site/doc/ros2/_downloads/
_site/doc/ros2/_downloads/97c67a555e198d8a224193fe961f770c
_site/doc/ros2/_downloads/97c67a555e198d8a224193fe961f770c/ros2-tsc-charter.pdf
_site/doc/ros2/_downloads/be940211da7b10813c678f8ee356f739
_site/doc/ros2/_downloads/be940211da7b10813c678f8ee356f739/ros2-brochure-ltr-print.pdf
_site/doc/ros2/_downloads/50f324bd6747229aa227cea87b196d82
_site/doc/ros2/_downloads/50f324bd6747229aa227cea87b196d82/ros2-brochure-a4-print.pdf
_site/doc/ros2/_downloads/8e95be988eb4e1795a9313b3ebc03875
_site/doc/ros2/_downloads/8e95be988eb4e1795a9313b3ebc03875/ros2-brochure-a4-web.pdf
_site/doc/ros2/_downloads/cab7bd9cff323a3b69ebb518707a1552
_site/doc/ros2/_downloads/cab7bd9cff323a3b69ebb518707a1552/ros2-brochure-ltr-web.pdf