### PR TITLE
Exit from dockerfile when 'make' was not successful

### DIFF
--- a/docker/image/update_site.sh
+++ b/docker/image/update_site.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 REPO_PATH=${1:-`pwd`}
 SITE_PATH=${2:-${REPO_PATH}/_site}


### PR DESCRIPTION
if `build_site.sh` returns non-zero, do not execute `git_add_files.py` or `git` and return the non-zero exit code.

https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html

Should address false positive job status like this one: http://build.ros.org/job/doc_rosindex/84