### PR TITLE
Ignore improperly encoded content

### DIFF
--- a/docker/image/git_add_files.py
+++ b/docker/image/git_add_files.py
@@ -27,7 +27,7 @@ def run(args):
     for diff_item in diff_index.iter_change_type('M'):
         filename = diff_item.a_path
         if filename in modified_files:
-            diff_string = diff_item.a_blob.data_stream.read().decode('utf-8')
+            diff_string = diff_item.a_blob.data_stream.read().decode('utf-8', 'ignore')
             modified_files[filename]["blacklisted"] = "generated on" in diff_string
 
     # Add all files to git


### PR DESCRIPTION
Fixes #179

We are only checking if the string has certain values. If it has other values we don't care. 