### PR TITLE
Add space between 'ROS' and '2' in docs page description

### DIFF
--- a/index.yml
+++ b/index.yml
@@ -19,4 +19,4 @@ attic_file: _remotes/rosforks/attic.yaml
 # correspond to documentation repos.
 docs_repos:
   ros2:
-    description: "ROS2 Overview"
+    description: "ROS 2 Overview"


### PR DESCRIPTION
Which, if I'm not mistaken, is what we see here:

![ros2_overview_pr](https://user-images.githubusercontent.com/3717345/66261352-884ba600-e780-11e9-8a8d-4cf6d7d7317d.png)

IIRC having a space between "ROS" and "2" is the preferred usage, but I can't find anything right now to back this up.