### PR TITLE
Fix the canonical url for the site.

### DIFF
--- a/index.yml
+++ b/index.yml
@@ -4,7 +4,7 @@ title: ROS Index
 description: > # this means to ignore newlines until "baseurl:"
   a community-maintained index of robotics software
 baseurl: "" # the subpath of your site, e.g. /blog/
-url: "https://ros-infrastructure.github.io/index.ros.org/" # the base hostname & protocol for your site
+url: "https://index.ros.org" # the base hostname & protocol for your site
 #twitter_username: jekyllrb
 github_username:  ros-infrastructure
 keep_files: [cache, .git]


### PR DESCRIPTION
All the pages on index.ros.org have incorrect canonical urls for example:

https://github.com/ros-infrastructure/index.ros.org/blob/e9ade17e0f45f2d321f350b583fc0e17fcbcf0de/doc/ros2/Releases/Release-Eloquent-Elusor/index.html#L14

`    <link rel="canonical" href="https://ros-infrastructure.github.io/index.ros.org//doc/ros2/Releases/Release-Eloquent-Elusor/">`

https://github.com/ros-infrastructure/index.ros.org/blob/e9ade17e0f45f2d321f350b583fc0e17fcbcf0de/packages/PCL/index.html#L14

They work because github redirects them to the regular url. But it looks really weird on the Google Search where it shows the full path before the redirect. 

![Screenshot from 2019-10-08 16-01-38](https://user-images.githubusercontent.com/447804/66439590-f5f80c00-e9e4-11e9-920b-a9031342703e.png)

I suspect that this discontinuity is not helping our page ranking etc and is confusing to users who shouldn't see these internals of the hosting.

This should fix both the wrong hostname and the double slash.
