### PR TITLE
Display CI Information (CI-badge)

### DIFF
--- a/_includes/package_body.html
+++ b/_includes/package_body.html
@@ -84,6 +84,16 @@ Assumes distro and package are defined
                 </td>
               </tr>
               <tr>
+                <td class="text-right"><b>Continuous Integration</b></td>
+                <td>
+                  {% if package.data.ci_data.error %}
+                    <span class="label label-default">No Continuous Integration
+                  {% else %}
+                    <span class="label label-primary"><span class="glyphicon glyphicon-check"></span>Continuous Integration
+                  {% endif %}</span>
+                </td>
+              </tr>
+              <tr>
                 <td class="text-right"><strong>Use</strong></td>
                 <td>
                 {% if package.data.deprecated and package.data.deprecated != '' %}

--- a/_includes/package_body.html
+++ b/_includes/package_body.html
@@ -85,35 +85,35 @@ Assumes distro and package are defined
               </tr>
               <tr>
                 <td class="text-right"><b>CI status</b></td>
-                <td style="position: absolute;">
+                <td class="ci-status">
                   {% assign ci_data = package.data.ci_data %}
                   {% if ci_data.ci_available %}
                     {% if ci_data.history_available %}
                       <div class="dropdown">
-                        <button type="button" data-toggle="dropdown" class="btn label label-primary dropdown-toggle" style="font-size: 75%; padding: .3em .6em .4em;border: 0;" title="{{ ci_data.tooltip }}">
+                        <button type="button" data-toggle="dropdown" class="btn label label-primary dropdown-toggle ci-result-{{ ci_data.result }}" title="{{ ci_data.tooltip }}">
                           <span class="glyphicon glyphicon-check"></span>
                           Continuous Integration
                           {% if ci_data.stats_available %}
                             : {{ ci_data.tests_ok }} / {{ ci_data.tests_total }}
                           {% endif %}
-                          <span class="caret" style="margin: 0 3px 0 5px;"></span>
+                          <span class="caret"></span>
                         </button>
                         <ul class="dropdown-menu" role="menu">
-                          <li class="dropdown-header">Build history (last {{ ci_data.history.size }} of {{ ci_data.total_builds }} builds):</li>
+                          <li class="dropdown-header">Latest build history: {{ ci_data.timestamp }} (last {{ ci_data.history.size }} of {{ ci_data.total_builds }} builds)</li>
                           {% for build in ci_data.history %}
-                            <li>
+                            <li class="ci-build-info ci-result-{{ build.result }}">
                               <a href="http://build.ros.org/{{ build.uri }}" target="_blank">
                                 <span class="glyphicon glyphicon-{{ build.icon }}"></span>
-                                <span style="font-weight: bold; padding-left: 10px;">#{{ build.id }}</span>
-                                <span style="color: #333; padding-left: 10px;">{{ build.stamp }}</span>
-                                <span style="color: #333; padding-left: 10px;">{{ build.tests_ok }} / {{ build.tests_total }}</span>
+                                <span><strong>#{{ build.id }}</strong></span>
+                                <span>{{ build.timestamp }}</span>
+                                <span>{{ build.tests_ok }} / {{ build.tests_total }}</span>
                               </a>
                             </li>
                           {% endfor %}
                         </ul>
                       </div>
                     {% else %}
-                      <a href="{{ ci_data.job_url }}" class="label label-primary" title="{{ ci_data.tooltip }}">
+                      <a href="{{ ci_data.job_url }}" class="label ci-result-{{ ci_data.result }}" title="{{ ci_data.tooltip }}">
                         <span class="glyphicon glyphicon-check"></span>
                         Continuous Integration
                         {% if ci_data.stats_available %}

--- a/_includes/package_body.html
+++ b/_includes/package_body.html
@@ -85,11 +85,9 @@ Assumes distro and package are defined
               </tr>
               <tr>
                 <td class="text-right"><b>CI status</b></td>
-                <td>
+                <td style="position: absolute;">
                   {% assign ci_data = package.data.ci_data %}
-                  {% if ci_data.error %}
-                    <span class="label label-default" title="{{ ci_data.tooltip }}">No Continuous Integration</span>
-                  {% else %}
+                  {% if ci_data.ci_available %}
                     {% if ci_data.history_available %}
                       <div class="dropdown">
                         <button type="button" data-toggle="dropdown" class="btn label label-primary dropdown-toggle" style="font-size: 75%; padding: .3em .6em .4em;border: 0;" title="{{ ci_data.tooltip }}">
@@ -104,7 +102,7 @@ Assumes distro and package are defined
                           <li class="dropdown-header">Build history (last {{ ci_data.history.size }} of {{ ci_data.total_builds }} builds):</li>
                           {% for build in ci_data.history %}
                             <li>
-                              <a href="{{ build.uri }}" target="_blank">
+                              <a href="http://build.ros.org/{{ build.uri }}" target="_blank">
                                 <span class="glyphicon glyphicon-{{ build.icon }}"></span>
                                 <span style="font-weight: bold; padding-left: 10px;">#{{ build.id }}</span>
                                 <span style="color: #333; padding-left: 10px;">{{ build.stamp }}</span>
@@ -115,14 +113,16 @@ Assumes distro and package are defined
                         </ul>
                       </div>
                     {% else %}
-                      <span class="label label-primary" title="{{ ci_data.tooltip }}">
+                      <a href="{{ ci_data.job_url }}" class="label label-primary" title="{{ ci_data.tooltip }}">
                         <span class="glyphicon glyphicon-check"></span>
                         Continuous Integration
                         {% if ci_data.stats_available %}
                           : {{ ci_data.tests_ok }} / {{ ci_data.tests_total }}
                         {% endif %}
-                      </span>
+                      </a>
                     {% endif %}
+                  {% else %}
+                    <span class="label label-default" title="{{ ci_data.tooltip }}">No Continuous Integration</span>
                   {% endif %}
                 </td>
               </tr>

--- a/_includes/package_body.html
+++ b/_includes/package_body.html
@@ -84,13 +84,46 @@ Assumes distro and package are defined
                 </td>
               </tr>
               <tr>
-                <td class="text-right"><b>Continuous Integration</b></td>
+                <td class="text-right"><b>CI status</b></td>
                 <td>
-                  {% if package.data.ci_data.error %}
-                    <span class="label label-default">No Continuous Integration
+                  {% assign ci_data = package.data.ci_data %}
+                  {% if ci_data.error %}
+                    <span class="label label-default" title="{{ ci_data.tooltip }}">No Continuous Integration</span>
                   {% else %}
-                    <span class="label label-primary"><span class="glyphicon glyphicon-check"></span>Continuous Integration
-                  {% endif %}</span>
+                    {% if ci_data.history_available %}
+                      <div class="dropdown">
+                        <button type="button" data-toggle="dropdown" class="btn label label-primary dropdown-toggle" style="font-size: 75%; padding: .3em .6em .4em;border: 0;" title="{{ ci_data.tooltip }}">
+                          <span class="glyphicon glyphicon-check"></span>
+                          Continuous Integration
+                          {% if ci_data.stats_available %}
+                            : {{ ci_data.tests_ok }} / {{ ci_data.tests_total }}
+                          {% endif %}
+                          <span class="caret" style="margin: 0 3px 0 5px;"></span>
+                        </button>
+                        <ul class="dropdown-menu" role="menu">
+                          <li class="dropdown-header">Build history (last {{ ci_data.history.size }} of {{ ci_data.total_builds }} builds):</li>
+                          {% for build in ci_data.history %}
+                            <li>
+                              <a href="{{ build.uri }}" target="_blank">
+                                <span class="glyphicon glyphicon-{{ build.icon }}"></span>
+                                <span style="font-weight: bold; padding-left: 10px;">#{{ build.id }}</span>
+                                <span style="color: #333; padding-left: 10px;">{{ build.stamp }}</span>
+                                <span style="color: #333; padding-left: 10px;">{{ build.tests_ok }} / {{ build.tests_total }}</span>
+                              </a>
+                            </li>
+                          {% endfor %}
+                        </ul>
+                      </div>
+                    {% else %}
+                      <span class="label label-primary" title="{{ ci_data.tooltip }}">
+                        <span class="glyphicon glyphicon-check"></span>
+                        Continuous Integration
+                        {% if ci_data.stats_available %}
+                          : {{ ci_data.tests_ok }} / {{ ci_data.tests_total }}
+                        {% endif %}
+                      </span>
+                    {% endif %}
+                  {% endif %}
                 </td>
               </tr>
               <tr>

--- a/_includes/package_body.html
+++ b/_includes/package_body.html
@@ -84,49 +84,6 @@ Assumes distro and package are defined
                 </td>
               </tr>
               <tr>
-                <td class="text-right"><b>CI status</b></td>
-                <td class="ci-status">
-                  {% assign ci_data = package.data.ci_data %}
-                  {% if ci_data.ci_available %}
-                    {% if ci_data.history_available %}
-                      <div class="dropdown">
-                        <button type="button" data-toggle="dropdown" class="btn label label-primary dropdown-toggle ci-result-{{ ci_data.result }}" title="{{ ci_data.tooltip }}">
-                          <span class="glyphicon glyphicon-check"></span>
-                          Continuous Integration
-                          {% if ci_data.stats_available %}
-                            : {{ ci_data.tests_ok }} / {{ ci_data.tests_total }}
-                          {% endif %}
-                          <span class="caret"></span>
-                        </button>
-                        <ul class="dropdown-menu" role="menu">
-                          <li class="dropdown-header">Latest build history: {{ ci_data.timestamp }} (last {{ ci_data.history.size }} of {{ ci_data.total_builds }} builds)</li>
-                          {% for build in ci_data.history %}
-                            <li class="ci-build-info ci-result-{{ build.result }}">
-                              <a href="http://build.ros.org/{{ build.uri }}" target="_blank">
-                                <span class="glyphicon glyphicon-{{ build.icon }}"></span>
-                                <span><strong>#{{ build.id }}</strong></span>
-                                <span>{{ build.timestamp }}</span>
-                                <span>{{ build.tests_ok }} / {{ build.tests_total }}</span>
-                              </a>
-                            </li>
-                          {% endfor %}
-                        </ul>
-                      </div>
-                    {% else %}
-                      <a href="{{ ci_data.job_url }}" class="label ci-result-{{ ci_data.result }}" title="{{ ci_data.tooltip }}">
-                        <span class="glyphicon glyphicon-check"></span>
-                        Continuous Integration
-                        {% if ci_data.stats_available %}
-                          : {{ ci_data.tests_ok }} / {{ ci_data.tests_total }}
-                        {% endif %}
-                      </a>
-                    {% endif %}
-                  {% else %}
-                    <span class="label label-default" title="{{ ci_data.tooltip }}">No Continuous Integration</span>
-                  {% endif %}
-                </td>
-              </tr>
-              <tr>
                 <td class="text-right"><strong>Use</strong></td>
                 <td>
                 {% if package.data.deprecated and package.data.deprecated != '' %}

--- a/_includes/repo_summary.html
+++ b/_includes/repo_summary.html
@@ -43,6 +43,49 @@
         {% endif %}</span>
       </td>
     </tr>
+              <tr>
+                <td class="text-right"><b>CI status</b></td>
+                <td class="ci-status">
+                  {% assign ci_data = package.data.ci_data %}
+                  {% if ci_data.ci_available %}
+                    {% if ci_data.history_available %}
+                      <div class="dropdown">
+                        <button type="button" data-toggle="dropdown" class="btn label label-primary dropdown-toggle ci-result-{{ ci_data.result }}" title="{{ ci_data.tooltip }}">
+                          <span class="glyphicon glyphicon-check"></span>
+                          Continuous Integration
+                          {% if ci_data.stats_available %}
+                            : {{ ci_data.tests_ok }} / {{ ci_data.tests_total }}
+                          {% endif %}
+                          <span class="caret"></span>
+                        </button>
+                        <ul class="dropdown-menu" role="menu">
+                          <li class="dropdown-header">Latest build history: {{ ci_data.timestamp }} (last {{ ci_data.history.size }} of {{ ci_data.total_builds }} builds)</li>
+                          {% for build in ci_data.history %}
+                            <li class="ci-build-info ci-result-{{ build.result }}">
+                              <a href="http://build.ros.org/{{ build.uri }}" target="_blank">
+                                <span class="glyphicon glyphicon-{{ build.icon }}"></span>
+                                <span><strong>#{{ build.id }}</strong></span>
+                                <span>{{ build.timestamp }}</span>
+                                <span>{{ build.tests_ok }} / {{ build.tests_total }}</span>
+                              </a>
+                            </li>
+                          {% endfor %}
+                        </ul>
+                      </div>
+                    {% else %}
+                      <a href="{{ ci_data.job_url }}" class="label ci-result-{{ ci_data.result }}" title="{{ ci_data.tooltip }}">
+                        <span class="glyphicon glyphicon-check"></span>
+                        Continuous Integration
+                        {% if ci_data.stats_available %}
+                          : {{ ci_data.tests_ok }} / {{ ci_data.tests_total }}
+                        {% endif %}
+                      </a>
+                    {% endif %}
+                  {% else %}
+                    <span class="label label-default" title="{{ ci_data.tooltip }}">No Continuous Integration</span>
+                  {% endif %}
+                </td>
+              </tr>
     <tr>
       <td class="text-right"><b>Released</b></td>
       <td>

--- a/_plugins/rosindex_generator.rb
+++ b/_plugins/rosindex_generator.rb
@@ -211,7 +211,7 @@ class Indexer < Jekyll::Generator
     return 'remove'
   end
 
-  def get_ci_data(distro, package_name)
+  def get_ci_data(distro, package_name, repo_name)
     ci_data = Hash.new
     manifest_url = '/'+distro+'/api/'+package_name+'/manifest.yaml'
     manifest_response = Net::HTTP.get_response('docs.ros.org', manifest_url)
@@ -234,7 +234,7 @@ class Indexer < Jekyll::Generator
     end
     ci_data['job_url'] = manifest_yaml['devel_jobs'][0]
     # get additional test information if available
-    results_url = '/'+distro+'/devel_jobs/'+package_name+'/results.yaml'
+    results_url = '/'+distro+'/devel_jobs/'+repo_name+'/results.yaml'
     results_response = Net::HTTP.get_response('docs.ros.org', results_url)
     if results_response.code != '200'
       ci_data['tooltip'] = "Latest build information: " + ci_data['timestamp'] + "\n" \
@@ -497,7 +497,7 @@ class Indexer < Jekyll::Generator
       end
 
       # try to acquire information on the CI status of the package
-      ci_data = get_ci_data(distro, package_name)
+      ci_data = get_ci_data(distro, package_name, repo.name)
 
       package_info = {
         'name' => package_name,

--- a/css/prettify.css
+++ b/css/prettify.css
@@ -1,1 +1,14 @@
 .pln{color:#000}@media screen{.str{color:#080}.kwd{color:#008}.com{color:#800}.typ{color:#606}.lit{color:#066}.clo,.opn,.pun{color:#660}.tag{color:#008}.atn{color:#606}.atv{color:#080}.dec,.var{color:#606}.fun{color:red}}@media print,projection{.kwd,.tag,.typ{font-weight:700}.str{color:#060}.kwd{color:#006}.com{color:#600;font-style:italic}.typ{color:#404}.lit{color:#044}.clo,.opn,.pun{color:#440}.tag{color:#006}.atn{color:#404}.atv{color:#060}}pre.prettyprint{padding:2px;border:1px solid #888}ol.linenums{margin-top:0;margin-bottom:0}li.L0,li.L1,li.L2,li.L3,li.L5,li.L6,li.L7,li.L8{list-style-type:none}li.L1,li.L3,li.L5,li.L7,li.L9{background:#eee}
+td.ci-status{position: absolute}
+td.ci-status button.dropdown-toggle{font-size: 75%; padding: .3em .6em .4em;border: 0}
+td.ci-status button.ci-result-success{background-color:#1f8c22}
+td.ci-status button.ci-result-failure{background-color:#ff4136}
+td.ci-status button.ci-result-unstable{background-color:#ff851b}
+td.ci-status a.ci-result-success{background-color:#1f8c22}
+td.ci-status a.ci-result-failure{background-color:#ff4136}
+td.ci-status a.ci-result-unstable{background-color:#ff851b}
+td.ci-status li.ci-result-success  span{color: #1f8c22}
+td.ci-status li.ci-result-failure  span{color: #ff4136}
+td.ci-status li.ci-result-unstable span{color: #ff851b}
+td.ci-status li.ci-build-info span.caret{margin: 0 3px 0 5px}
+td.ci-status li.ci-build-info span{padding-left: 10px}


### PR DESCRIPTION
(see Issue https://github.com/ros-infrastructure/rosindex/issues/78 for some background)

This PR adds information on the CI (continuous integration) status of the package displayed.

If the package has no information about it on the doc server, a negative "no CI" badge is displayed:
![image](https://user-images.githubusercontent.com/15894344/68836209-28d8a280-06fd-11ea-9bac-39a3c14cc9aa.png)



If the package has a `manifest.yaml` with dev job information, then a positive CI badge is displayed which is also a link to that job:
![image](https://user-images.githubusercontent.com/15894344/68835907-7b658f00-06fc-11ea-882b-b8f493e14c54.png)



If additionally test data is available (`results.yaml`), then the results of recent tests are also displayed as a drop-down menu, where each item in the list is a link to that specific job:
![image](https://user-images.githubusercontent.com/15894344/68836093-e4e59d80-06fc-11ea-8c44-24e3eb34e3fc.png)
