### PR TITLE
Disable lunr.js stemming.

### DIFF
--- a/node_modules/lunr-index-build/bin/lunr-index-build
+++ b/node_modules/lunr-index-build/bin/lunr-index-build
@@ -47,6 +47,9 @@ process.stdin.on('end', function () {
       this.field(fieldName, { boost: fieldBoost })
     }, this)
 
+    this.pipeline.remove(lunr.stemmer)
+    this.searchPipeline.remove(lunr.stemmer)
+
     this.metadataWhitelist = ['position'];
 
     documents.forEach(function (document) {


### PR DESCRIPTION
Closes #178. This pull request is actually a workaround, not a solution. Checking `lunr.js` issues upstream like https://github.com/olivernn/lunr.js/issues/413 and https://github.com/olivernn/lunr.js/issues/328 I've came to the conclusion that we won't get autocomplete like behavior from `lunr.js`. So, for the time being, I'll just disable stemming. This way, `python_cmake_mod` or `cmake_module` won't find `python_cmake_module` but `python_cmake_mod*` or `*_cmake_module` will, consistently.