### PR TITLE
Update ROS 2 distributions

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -86,8 +86,8 @@ index_old_doc_paths: false
 # drop-down list in the distro selector.
 #
 ros2_distros:
-  - 'dashing'
   - 'eloquent'
+  - 'dashing'
 
 ros_distros:
   - 'melodic'

--- a/_config.yml
+++ b/_config.yml
@@ -87,6 +87,7 @@ index_old_doc_paths: false
 #
 ros2_distros:
   - 'dashing'
+  - 'eloquent'
 
 ros_distros:
   - 'melodic'

--- a/_config.yml
+++ b/_config.yml
@@ -87,8 +87,6 @@ index_old_doc_paths: false
 #
 ros2_distros:
   - 'dashing'
-  - 'crystal'
-  - 'bouncy'
 
 ros_distros:
   - 'melodic'
@@ -96,6 +94,8 @@ ros_distros:
 
 old_ros2_distros:
   - 'ardent'
+  - 'bouncy'
+  - 'crystal'
 
 old_ros_distros:
   - 'lunar'


### PR DESCRIPTION
Bouncy and Crystal have both reached end of support and Eloquent hasn't been added yet.

cc #123 