### PR TITLE
Display only package-specific tags in package summary box.

### DIFF
--- a/_includes/package_body.html
+++ b/_includes/package_body.html
@@ -56,9 +56,9 @@ Assumes distro and package are defined
               <tr>
                 <td style="width:100px;" class="text-right"><strong>Tags</strong></td>
                 <td>
-                  {% assign n_tags = package.repo.tags.size %}
+                  {% assign n_tags = package.data.tags.size %}
                   {% if n_tags > 0 %}
-                    {% for tag in package.repo.tags %}<span class="label label-default">{{ tag }}</span> {% endfor %}
+                    {% for tag in package.data.tags %}<span class="label label-default">{{ tag }}</span> {% endfor %}
                   {% else %}
                     <em>No category tags.</em>
                   {% endif %}

--- a/_includes/repo_summary.html
+++ b/_includes/repo_summary.html
@@ -53,4 +53,15 @@
         {% endif %}</span>
       </td>
     </tr>
+    <tr>
+      <td class="text-right"><b>Package Tags</b></td>
+      <td>
+        {% assign n_tags = repo.tags.size %}
+        {% if n_tags > 0 %}
+          {% for tag in repo.tags %}<span class="label label-default">{{ tag }}</span> {% endfor %}
+        {% else %}
+          <em>No category tags.</em>
+        {% endif %}
+      </td>
+    </tr>
   </table>


### PR DESCRIPTION
This is a PR to attempt to solve [#198](https://github.com/ros-infrastructure/rosindex/issues/198) / [#146](https://github.com/rosindex/rosindex/issues/146):

The *"Package Summary"* box now only shows those tags associated with that package, not the repository of the package.

For example:
- the package *fanuc* displays: `metapackage` `fanuc` `industrial` `ros-industrial`
- the package *fanuc_lrmate200ic_support * displays: `support_package` `description` `fanuc` `industrial` `ros-industrial` `lrmate200ic`
- the package *fanuc_m430ia2p_moveit_config* displays: `moveit` `fanuc` `industrial` `ros-industrial m430ia`

The *"Repository Summary"* box, the aggregate tags are shown.

![image](https://user-images.githubusercontent.com/15894344/71071130-53929c80-217c-11ea-9e99-3ce2087ae507.png)

![image](https://user-images.githubusercontent.com/15894344/71071194-6dcc7a80-217c-11ea-9e81-4ca7cdca420b.png)