### PR TITLE
resolve the mismatch between the bundler version.

### DIFF
--- a/docker/image/Dockerfile
+++ b/docker/image/Dockerfile
@@ -68,6 +68,10 @@ WORKDIR $HOME
 COPY Gemfile* .bundle/
 RUN chown -R $user:$user .
 
+# Work around https://bundler.io/blog/2019/05/14/solutions-for-cant-find-gem-bundler-with-executable-bundle.html
+# This is needed until we upgrade to a platform with ruby 2.6.3 or higher
+RUN gem install bundler -v "$(grep -A 1 "BUNDLED WITH" .bundle/Gemfile.lock | tail -n 1)"
+
 USER $user
 ENV BUNDLE_PATH=$HOME/.bundle
 ENV BUNDLE_GEMFILE=$HOME/.bundle/Gemfile


### PR DESCRIPTION
This fixes #200.

It's a known issue with RubyGems and the bundler version.

https://bundler.io/blog/2019/05/14/solutions-for-cant-find-gem-bundler-with-executable-bundle.html

I manually reconfigured this job to use the proposed branch and it has passed the critical stage: http://build.ros.org/job/doc_rosindex/276/