### PR TITLE
Fixed highlighting the sorting column on repo page.

### DIFF
--- a/_layouts/repos.html
+++ b/_layouts/repos.html
@@ -60,7 +60,7 @@ layout: default
                     {% endif %}
                   </th>
                   <th style="text-align: left;">
-                    {% if page.sort_id == '' %}
+                    {% if page.sort_id == 'name' %}
                       <span class="selected-sort-label">Name</span>
                     {% else %}
                       <a class="unselected-sort-label" href="/repos/page/1/name">Name</a>


### PR DESCRIPTION
Currently, when the repo page is sorted by repo name, the column header is not highlighted and remains a 'sort-by-this-column' hyperlink.
This small patch fixes this behavior.

![image](https://user-images.githubusercontent.com/15894344/72484204-d889d800-3846-11ea-97ba-cfb5b5c8ab72.png)
