### PR TITLE
Remove indexing by presence of a readme

### DIFF
--- a/_layouts/deps.html
+++ b/_layouts/deps.html
@@ -31,13 +31,6 @@ layout: default
                 {% endif %}
               </th>
               <th style="text-align: center;">
-                {% if page.sort_id == 'doc' %}
-                  <span class="glyphicon glyphicon-file selected-sort-label"></span>
-                {% else %}
-                  <a href="{{site.baseurl}}/packages/page/1/doc" class="unselected-sort-label glyphicon glyphicon-file"></a>
-                {% endif %}
-              </th>
-              <th style="text-align: center;">
                 {% if page.sort_id == 'time' %}
                   <span class="glyphicon glyphicon-time selected-sort-label"></span>
                 {% else %}
@@ -72,15 +65,6 @@ layout: default
                     </td>
                   {% else %}
                     <td title="Not released in {{distro}}" data-toggle="tooltip" data-placement="left" class="text-center">
-                      <span class="glyphicon glyphicon-none"></span>
-                    </td>
-                  {% endif %}
-                  {% if p.data.readme %}
-                    <td title="Has README" data-toggle="tooltip" data-placement="left" align="center">
-                      <span class="glyphicon glyphicon-file"></span>
-                    </td>
-                  {% else %}
-                    <td title="No README" data-toggle="tooltip" data-placement="left" align="center">
                       <span class="glyphicon glyphicon-none"></span>
                     </td>
                   {% endif %}

--- a/_layouts/packages.html
+++ b/_layouts/packages.html
@@ -39,16 +39,6 @@ layout: default
                     {% endif %}
                   </th>
                   <th style="text-align: center;">
-                    {% if page.sort_id == 'doc' %}
-                      <span class="glyphicon glyphicon-file selected-sort-label"
-                            title="Sorted by README status"></span>
-                    {% else %}
-                      <a href="{{site.baseurl}}/packages/page/1/doc"
-                         class="unselected-sort-label glyphicon glyphicon-file"
-                         title="Sort by README status"></a>
-                    {% endif %}
-                  </th>
-                  <th style="text-align: center;">
                     {% if page.sort_id == 'time' %}
                       <span class="glyphicon glyphicon-time selected-sort-label"
                             title="Sorted by last commit date"></span>
@@ -89,16 +79,6 @@ layout: default
                       </td>
                     {% else %}
                       <td title="Not released in {{distro}}" data-toggle="tooltip" data-placement="left" class="text-center">
-                        <span class="glyphicon glyphicon-none"></span>
-                      </td>
-                    {% endif %}
-                    {% assign n_readmes = p.data[1].readmes | size %}
-                    {% if n_readmes > 0 %}
-                      <td title="Has README" data-toggle="tooltip" data-placement="left" align="center">
-                        <span class="glyphicon glyphicon-file"></span>
-                      </td>
-                    {% else %}
-                      <td title="No README" data-toggle="tooltip" data-placement="left" align="center">
                         <span class="glyphicon glyphicon-none"></span>
                       </td>
                     {% endif %}

--- a/_layouts/repos.html
+++ b/_layouts/repos.html
@@ -40,16 +40,6 @@ layout: default
                     {% endif %}
                   </th>
                   <th style="text-align: center;">
-                    {% if page.sort_id == 'doc' %}
-                      <span class="glyphicon glyphicon-file selected-sort-label"
-                            title="Sorted by README status"></span>
-                    {% else %}
-                      <a href="{{site.baseurl}}/repos/page/1/doc"
-                         class="unselected-sort-label glyphicon glyphicon-file"
-                         title="Sort by README status"></a>
-                    {% endif %}
-                  </th>
-                  <th style="text-align: center;">
                     {% if page.sort_id == 'time' %}
                       <span class="glyphicon glyphicon-time selected-sort-label"
                             title="Sorted by last commit date"></span>
@@ -87,15 +77,6 @@ layout: default
                       </td>
                     {% else %}
                       <td title="Not released in {{distro}}" data-toggle="tooltip" data-placement="left" class="text-center">
-                        <span class="glyphicon glyphicon-none"></span>
-                      </td>
-                    {% endif %}
-                    {% if r.data.readme %}
-                      <td title="Has README" data-toggle="tooltip" data-placement="left" align="center">
-                        <span class="glyphicon glyphicon-file"></span>
-                      </td>
-                    {% else %}
-                      <td title="No README" data-toggle="tooltip" data-placement="left" align="center">
                         <span class="glyphicon glyphicon-none"></span>
                       </td>
                     {% endif %}

--- a/_plugins/rosindex_generator.rb
+++ b/_plugins/rosindex_generator.rb
@@ -681,7 +681,7 @@ class Indexer < Jekyll::Generator
   end
 
   def sort_repos(site)
-    repos_sorted = {'name' => {}, 'time' => {}, 'doc' => {}, 'released' => {}}
+    repos_sorted = {'name' => {}, 'time' => {}, 'released' => {}}
 
     repos_sorted_by_name = @repo_names.sort_by { |name, _| name }
     $all_distros.collect do |distro|
@@ -696,13 +696,6 @@ class Indexer < Jekyll::Generator
         end.max.to_s
       end.reverse
 
-      repos_sorted['doc'][distro] = \
-      repos_sorted['name'][distro].sort_by do |_, instances|
-        instances.default.snapshots.count do |d, s|
-          d == distro and not s.nil? and not s.data['readme'].nil?
-        end
-      end.reverse
-
       repos_sorted['released'][distro] = \
       repos_sorted['name'][distro].sort_by do |_, instances|
         instances.default.snapshots.count do |d, s|
@@ -715,7 +708,7 @@ class Indexer < Jekyll::Generator
   end
 
   def sort_packages(site)
-    packages_sorted = {'name' => {}, 'time' => {}, 'doc' => {}, 'released' => {}}
+    packages_sorted = {'name' => {}, 'time' => {}, 'released' => {}}
 
     packages_sorted_by_name = @package_names.sort_by { |name, _| name }
     $all_distros.each do |distro|
@@ -728,13 +721,6 @@ class Indexer < Jekyll::Generator
         end.map do |_, s|
           s.snapshot.data['last_commit_time'].to_s
         end.max.to_s
-      end.reverse
-
-      packages_sorted['doc'][distro] = \
-      packages_sorted['name'][distro].sort_by do |_, instances|
-        instances.snapshots.count do |d, s|
-          distro == d and not s.nil? and s.data['readmes'].count > 0
-        end
       end.reverse
 
       packages_sorted['released'][distro] = \


### PR DESCRIPTION
This will save a whole dimention on our pagination generation and save ~200 page renders

There's ~150 pagniations of packages and  39 repos

This is a first pass to resolve #207