### PR TITLE
Increase the number of listings per page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -105,8 +105,8 @@ old_ros_distros:
   - 'hydro'
 
 # package list page
-packages_per_page: 100
-repos_per_page: 100
+packages_per_page: 200
+repos_per_page: 200
 
 # uncomment the following line for testing (limit the number of indexed repos)
 max_repos: 00

--- a/_config.yml
+++ b/_config.yml
@@ -105,8 +105,8 @@ old_ros_distros:
   - 'hydro'
 
 # package list page
-packages_per_page: 50
-repos_per_page: 50
+packages_per_page: 100
+repos_per_page: 100
 
 # uncomment the following line for testing (limit the number of indexed repos)
 max_repos: 00


### PR DESCRIPTION
This will make each page bigger, but create fewer paginations.

This will halve the number of pagination pages. Currently ~150 across 5 dimentions which will be a lot fewer pages.

Hoping that this will reduce memory footprint of the rendering for #207