### PR TITLE
Updated the rendering of the package links box

### DIFF
--- a/_includes/package_links.html
+++ b/_includes/package_links.html
@@ -30,16 +30,18 @@ Assumes the following are defined:
        {%if hide_link_labels%}<br>{%endif%}
        Browse Code
   </a>
-  {% if page.available_distros["noetic"]
-     or page.available_distros["melodic"]
-     or page.available_distros["kinetic"]
-     or page.available_distros["ardent"]
-     or page.available_distros["bouncy"]
-     or page.available_distros["lunar"]
-     or page.available_distros["jade"]
-     or page.available_distros["indigo"]
-     or page.available_distros["hydro"]
-  %}
+  {% assign has_ros1 = false %}
+  {% for ros_distro in site.ros_distros %}
+    {% if page.available_distros[ros_distro] %}
+      {% assign has_ros1 = true %}
+    {% endif %}
+  {% endfor %}
+  {% for old_ros_distro in site.old_ros_distros %}
+    {% if page.available_distros[old_ros_distro] %}
+      {% assign has_ros1 = true %}
+    {% endif %}
+  {% endfor %}
+  {% if has_ros1 %}
   <a class="{{list_group_class}} {% comment %} TODO: rosindex currently does not detect if a wiki page exists - implement and then re-enable the following: {% unless package.data.wiki.exists %}inactive{% endunless %} {% endcomment %}"
      target="_blank"
      href="http://wiki.ros.org/{{page.package_name}}?distro={{distro}}"

--- a/_includes/package_links.html
+++ b/_includes/package_links.html
@@ -30,6 +30,16 @@ Assumes the following are defined:
        {%if hide_link_labels%}<br>{%endif%}
        Browse Code
   </a>
+  {% if page.available_distros["noetic"]
+     or page.available_distros["melodic"]
+     or page.available_distros["kinetic"]
+     or page.available_distros["ardent"]
+     or page.available_distros["bouncy"]
+     or page.available_distros["lunar"]
+     or page.available_distros["jade"]
+     or page.available_distros["indigo"]
+     or page.available_distros["hydro"]
+  %}
   <a class="{{list_group_class}} {% comment %} TODO: rosindex currently does not detect if a wiki page exists - implement and then re-enable the following: {% unless package.data.wiki.exists %}inactive{% endunless %} {% endcomment %}"
      target="_blank"
      href="http://wiki.ros.org/{{page.package_name}}?distro={{distro}}"
@@ -38,10 +48,12 @@ Assumes the following are defined:
        {%if hide_link_labels%}<br>{%endif%}
        Wiki
   </a>
+  {%endif%}
   <a class="{{list_group_class}}"
      target="_blank" 
      href="http://http404error.github.io/roseco/graph.html?id=ros.json&focus={{page.package_name}}&height=1&depth=2&tred=standard&metagroup=false&colorby=Health&direction=LR"
-     title="View RosEco package graph">
+     title="View RosEco package graph"
+     {% unless package.snapshot.documented %}disabled{% endunless %}>
        <span style="margin-right: 5px;" class="glyphicon glyphicon-tree-deciduous"></span>
        {%if hide_link_labels%}<br>{%endif%}
        RosEco

--- a/_includes/package_links.html
+++ b/_includes/package_links.html
@@ -13,9 +13,38 @@ Assumes the following are defined:
 {% endif %}
 
 <div class="list-group list-group-sm {%if horizontal%}list-group-horizontal list-group-justified{%endif%}">
-  <a class="{{list_group_class}}" target="_blank" href="{{ package.data.docs_uri }}" {% unless package.snapshot.documented %}disabled{% endunless %}><span style="margin-right: 5px;" class="glyphicon glyphicon-file"></span>{%if hide_link_labels%}<br>{%endif%} API Docs</a>
-  <a class="{{list_group_class}}" target="_blank" href="{{ package.data.browse_uri }}"><span class="glyphicon glyphicon-folder-open" style="margin-right:5px;"></span>{%if hide_link_labels%}<br>{%endif%} Browse Code</a>
-  <a class="{{list_group_class}} {% unless package.data.wiki.exists %}inactive{% endunless %}" target="_blank" href="http://wiki.ros.org/{{page.package_name}}?distro={{distro}}"><span style="margin-right: 5px;" class="glyphicon glyphicon-info-sign"></span>{%if hide_link_labels%}<br>{%endif%} Wiki</a>
-  <a class="{{list_group_class}} {% unless package.data.wiki.exists %}inactive{% endunless %}" target="_blank" href="http://http404error.github.io/roseco/graph.html?id=ros.json&focus={{page.package_name}}&height=1&depth=2&tred=standard&metagroup=false&colorby=Health&direction=LR" {% unless package.snapshot.documented %}disabled{% endunless %}><span style="margin-right: 5px;" class="glyphicon glyphicon-tree-deciduous"></span>{%if hide_link_labels%}<br>{%endif%}</a>
+  <a class="{{list_group_class}}"
+     target="_blank"
+     href="{{ package.data.docs_uri }}"
+     title="View API documentation on docs.ros.org"
+     {% unless package.snapshot.documented %}disabled{% endunless %}>
+       <span style="margin-right: 5px;" class="glyphicon glyphicon-file"></span>
+       {%if hide_link_labels%}<br>{%endif%}
+       API Docs
+  </a>
+  <a class="{{list_group_class}}"
+     target="_blank"
+     href="{{ package.data.browse_uri }}"
+     title="View source code on repository">
+       <span class="glyphicon glyphicon-folder-open" style="margin-right:5px;"></span>
+       {%if hide_link_labels%}<br>{%endif%}
+       Browse Code
+  </a>
+  <a class="{{list_group_class}} {% comment %} TODO: rosindex currently does not detect if a wiki page exists - implement and then re-enable the following: {% unless package.data.wiki.exists %}inactive{% endunless %} {% endcomment %}"
+     target="_blank"
+     href="http://wiki.ros.org/{{page.package_name}}?distro={{distro}}"
+     title="View this package on wiki.ros.org">
+       <span style="margin-right: 5px;" class="glyphicon glyphicon-info-sign"></span>
+       {%if hide_link_labels%}<br>{%endif%}
+       Wiki
+  </a>
+  <a class="{{list_group_class}}"
+     target="_blank" 
+     href="http://http404error.github.io/roseco/graph.html?id=ros.json&focus={{page.package_name}}&height=1&depth=2&tred=standard&metagroup=false&colorby=Health&direction=LR"
+     title="View RosEco package graph">
+       <span style="margin-right: 5px;" class="glyphicon glyphicon-tree-deciduous"></span>
+       {%if hide_link_labels%}<br>{%endif%}
+       RosEco
+  </a>
   {% comment %}<a type="button" class="list-group-item {%if horizontal %}text-center{%endif%} inactive" target="_blank" ><span class="glyphicon glyphicon-fire"></span>{%if hide_link_labels%} CI{%endif%}</a>{% endcomment %}
 </div>


### PR DESCRIPTION
This is to address #91 and #92.

![image](https://user-images.githubusercontent.com/15894344/72589881-cfc8fd00-393f-11ea-85a8-08ea032a9b81.png)

- RosEco link now has a text
- All links now have tool-tips
- Wiki and RosEco links are now enabled

Caveats:
- It was suggested that wiki links are not displayed
  for ROS2 packages, but I believe some ROS2 packages
  do indeed have wiki pages. In the long run,
  I heard that the wiki should be discontinued anyways,
  so I'm not sure how much sense it makes to add
  specific code to detect if a package is ROS1 or ROS2
- The wiki link is supposed to be disabled when no
  wiki page for the package exists. But no such
  code is in the rosindex sources yet and I don't know
  of any way to detect it except querying the page
  and parsing it's contents for "This page does not exists".
- On the RosEco link there was a conditional to make
  it disabled when no documentation for the package
  was available on docs.ros.org. I don't understand
  how RosEco works, but it seemed like a copy-and-paste
  mistake, so I removed it.