### PR TITLE
Split the site generation into two stages norender and render

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@ discover_config=_config/discover.yml
 update_config=_config/update.yml
 scrape_config=_config/scrape.yml
 search_config=_config/search_index.yml
+norender_config=_config/norender.yml
+onlyrender_config=_config/onlyrender.yml
 
 build: prepare-sources
 	bundle exec jekyll build --verbose --trace -d $(site_path) --config=$(config_file),$(index_file)
@@ -33,6 +35,13 @@ scrape: prepare-sources
 
 search-index: prepare-sources
 	bundle exec jekyll build --verbose --trace -d $(site_path) --config=$(config_file),$(index_file),$(search_config)
+
+norender: prepare-sources
+	bundle exec jekyll build --verbose --trace -d $(site_path) --config=$(config_file),$(index_file),$(norender_config)
+
+# Call norender from a second process so that it's split into a separate ruby process and the memory is cleared between the scraping process and the rendering process.
+render: norender
+	bundle exec jekyll build --verbose --trace -d $(site_path) --config=$(config_file),$(index_file),$(onlyrender_config)
 
 serve:
 	bundle exec jekyll serve --host 0.0.0.0 --no-watch --trace -d $(site_path) --config=$(config_file),$(index_file) --skip-initial-build

--- a/_config.yml
+++ b/_config.yml
@@ -42,6 +42,9 @@ skip_update: false
 skip_scrape: false
 # If true, this skips generating the search index
 skip_search_index: false
+# If true, this skips adding content in the generator
+skip_rosindex_generation: false
+
 # Shard count for search index partitioning.
 search_index_shards: 20
 

--- a/_config/norender.yml
+++ b/_config/norender.yml
@@ -1,0 +1,1 @@
+skip_rosindex_generation: true

--- a/_config/onlyrender.yml
+++ b/_config/onlyrender.yml
@@ -1,0 +1,7 @@
+# If true, this skips finding repos based on the repo sources
+skip_discover: true
+# If true, this skips updating the known repos
+skip_update: true
+# If true, this skips scraping the cloned repos
+skip_scrape: true
+

--- a/_plugins/rosindex_generator.rb
+++ b/_plugins/rosindex_generator.rb
@@ -959,6 +959,7 @@ class Indexer < Jekyll::Generator
     @skip_discover = site.config['skip_discover']
     @skip_update = site.config['skip_update']
     @skip_scrape = site.config['skip_scrape']
+    @skip_rosindex_generation = site.config['skip_rosindex_generation']
 
     if @use_db_cache
       puts ("Reading cache: " << @db_cache_filename).blue
@@ -1399,6 +1400,10 @@ class Indexer < Jekyll::Generator
       db_cache_dirname = File.dirname(@db_cache_filename)
       Dir.mkdir(db_cache_dirname) unless File.directory?(db_cache_dirname)
       File.open(@db_cache_filename, 'w') {|f| f.write(Marshal.dump(@db)) }
+    end
+
+    if @skip_rosindex_generation
+      return ''
     end
 
     puts "Generating update report...".blue

--- a/docker/image/build_site.sh
+++ b/docker/image/build_site.sh
@@ -2,4 +2,4 @@
 
 REPO_PATH=${1:-`pwd`}
 SITE_PATH=${2:-${REPO_PATH}/_site}
-make -C $REPO_PATH build site_path=$SITE_PATH
+make -C $REPO_PATH render site_path=$SITE_PATH


### PR DESCRIPTION
We seem to run up to 2.5GB of memory when finishing the scraping. And then increase from there for the render phase. This splits the generation into two stages. The first most of the rendering is disabled. And the second skips all the scraping.

In the long run we should actually have separate processes and cache the scraping results so that the rendering can be decoupled from the scraping. And possibly the scraping be made more modular and tirggered on demand by releases etc. But for now this will hopefully alleviate #207 by splitting it into two different invocations of ruby and thus using the process management to force cleanup of the memory used in the first stage that's not collected by the garbage collector.