### PR TITLE
Disable links to missing API docs.

### DIFF
--- a/_includes/package_links.html
+++ b/_includes/package_links.html
@@ -13,17 +13,22 @@ Assumes the following are defined:
 {% endif %}
 
 <div class="list-group list-group-sm {%if horizontal%}list-group-horizontal list-group-justified{%endif%}">
-  <a class="{{list_group_class}} {% if package.data.docs_uri == '' %}disabled{% endif %}" target="_blank"
-     {% if package.data.docs_uri == '' %}
-     href="javascript:void(0)"
-     {% else %}
-     href="{{ package.data.docs_uri }}"
-     {% endif %}
+  {% if package.data.docs_uri == '' %}
+  <div class="{{list_group_class}} disabled" 
      title="View API documentation">
        <span style="margin-right: 5px;" class="glyphicon glyphicon-file"></span>
        {%if hide_link_labels%}<br>{%endif%}
        API Docs
+  </div>
+  {% else %} 
+  <a class="{{list_group_class}}" target="_blank"
+    href="{{ package.data.docs_uri }}"
+    title="View API documentation">
+      <span style="margin-right: 5px;" class="glyphicon glyphicon-file"></span>
+      {%if hide_link_labels%}<br>{%endif%}
+      API Docs
   </a>
+{% endif %}
   <a class="{{list_group_class}}"
      target="_blank"
      href="{{ package.data.browse_uri }}"

--- a/_includes/package_links.html
+++ b/_includes/package_links.html
@@ -14,8 +14,11 @@ Assumes the following are defined:
 
 <div class="list-group list-group-sm {%if horizontal%}list-group-horizontal list-group-justified{%endif%}">
   <a class="{{list_group_class}} {% if package.data.docs_uri == '' %}disabled{% endif %}" target="_blank"
-     {% unless package.data.docs_uri == '' %}href="{{ package.data.docs_uri }}"{% endunless %}
-     {% if package.data.docs_uri == '' %}href="javascript:void(0)"{% endif %}
+     {% if package.data.docs_uri == '' %}
+     href="javascript:void(0)"
+     {% else %}
+     href="{{ package.data.docs_uri }}"
+     {% endif %}
      title="View API documentation">
        <span style="margin-right: 5px;" class="glyphicon glyphicon-file"></span>
        {%if hide_link_labels%}<br>{%endif%}

--- a/_includes/package_links.html
+++ b/_includes/package_links.html
@@ -13,11 +13,10 @@ Assumes the following are defined:
 {% endif %}
 
 <div class="list-group list-group-sm {%if horizontal%}list-group-horizontal list-group-justified{%endif%}">
-  <a class="{{list_group_class}}"
-     target="_blank"
-     href="{{ package.data.docs_uri }}"
-     title="View API documentation on docs.ros.org"
-     {% unless package.snapshot.documented %}disabled{% endunless %}>
+  <a class="{{list_group_class}} {% if package.data.docs_uri == '' %}disabled{% endif %}" target="_blank"
+     {% unless package.data.docs_uri == '' %}href="{{ package.data.docs_uri }}"{% endunless %}
+     {% if package.data.docs_uri == '' %}href="javascript:void(0)"{% endif %}
+     title="View API documentation">
        <span style="margin-right: 5px;" class="glyphicon glyphicon-file"></span>
        {%if hide_link_labels%}<br>{%endif%}
        API Docs

--- a/_plugins/rosindex_generator.rb
+++ b/_plugins/rosindex_generator.rb
@@ -14,7 +14,7 @@ require 'json'
 require 'uri'
 require 'set'
 require 'yaml'
-require "net/http"
+require 'net/http'
 require 'thread'
 
 # local libs
@@ -511,6 +511,15 @@ class Indexer < Jekyll::Generator
       else
         # ROS 2
         docs_uri = "http://docs.ros.org/#{DEFAULT_LANGUAGE_PREFIX}/#{distro}/p/#{package_name}"
+      end
+
+      # ensure documentation uri refers to an existing site
+      url = URI(docs_uri)
+      Net::HTTP.start(url.host, url.port) do |http|
+        response = http.head(url.path)
+        if response.code != '200'
+          docs_uri = ''
+        end
       end
 
       # try to acquire information on the CI status of the package

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -401,7 +401,7 @@ th.rotate45 {
 }
 
 .list-group-horizontal .list-group-item {
-  display: inline-block;
+  display: table-cell;
 }
 .list-group-horizontal .list-group-item {
   margin-bottom: 0;


### PR DESCRIPTION
Closes #218. This isn't particularly pretty, and we should check what impact per-package HTTP HEAD requests have on overall build time, but it has the desired effect.