### PR TITLE
Cache the page header

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -48,7 +48,7 @@
 
   <body>
 
-    {% include header.html %}
+    {% include_cached header.html %}
 
     <div class="page-content">
       <div class="wrapper">


### PR DESCRIPTION
It has no page specific content

This should save us over 24k evaluations of this file.

```
_includes/header.html                                                     | 24993 |  139658.15K |  15.734
```