### PR TITLE
don't test the server if it appears to have a valid origin

### DIFF
--- a/_ruby_libs/vcs.rb
+++ b/_ruby_libs/vcs.rb
@@ -92,16 +92,14 @@ class GIT < VCS
 
     if @origin.nil?
 
-      # check remote uri
-      begin
-        self.check_uri
-      rescue VCSException => e
-        raise VCSException.new("Could not reach git repository at uri: " + uri + ": " +e.msg)
-      end
-
       # add remote
       dputs " - adding remote for " << @uri << " to " << @local_path
-      @origin = @r.remotes.create('origin', @uri)
+      test_origin = @r.remotes.create('origin', @uri)
+
+      if not test_origin.check_connection(:fetch)
+        raise VCSException.new("Could not fetch from git repository at uri: " + uri)
+      end
+      @origin = test_origin
     end
   end
 


### PR DESCRIPTION
We were unnecessarily checking all the uris once every time in addition to fetching with adaquate error checking. Removing this appears to resolve #228 

Test run with this branch here: http://build.ros.org/job/doc_rosindex/457/console