### PR TITLE
Update aggregate tag list (at repository-level) heading

### DIFF
--- a/_includes/repo_summary.html
+++ b/_includes/repo_summary.html
@@ -97,7 +97,7 @@
       </td>
     </tr>
     <tr>
-      <td class="text-right"><b>Package Tags</b></td>
+      <td class="text-right"><b>Tags</b></td>
       <td>
         {% assign n_tags = repo.tags.size %}
         {% if n_tags > 0 %}


### PR DESCRIPTION
As per subject.

The tags listed in that section (ie: *Repository Summary*) are all the tags from all the packages in the repository.

The *Package Summary* does actually show the per-package tags, and it also doesn't repeat the *Package* prefix.

From the context it should be clear this list shows "repository tags".
