### PR TITLE
remove deprecated docs link from header

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -59,26 +59,6 @@
                   </ul>
                 </li>
 
-                <li class="dropdown disabled">
-                  <button id="dLabel" class="btn btn-link" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                    Doc <span class="caret"></span>
-                  </button>
-                  <ul class="dropdown-menu" role="menu" aria-labelledby="dLabel">
-                    {% for repo in site.docs_repos %}
-                    <li>
-                      <a href="{{site.baseurl}}/doc/{{ repo[0] }}">
-                        {{ repo[1].description }}
-                      </a>
-                    </li>
-                    {% endfor %}
-                    <li class="hidden" class="divider"></li>
-
-                    <li class="hidden"><a href="{{site.baseurl}}/doc/tutorials">Tutorials</a></li>
-                    <li class="hidden"><a href="{{site.baseurl}}/doc/readmes">Readmes</a></li>
-                    <li class="hidden"><a href="{{site.baseurl}}/doc/apis">APIs</a></li>
-                  </ul>
-                </li>
-
                 <li><a class="btn btn-link" href="{{site.baseurl}}/contribute">Contribute</a></li>
                 <li><a class="btn btn-link" href="{{site.baseurl}}/stats">Stats</a></li>
               </ul>


### PR DESCRIPTION
The documentation has been migrated to docs.ros.org  https://discourse.ros.org/t/index-ros-org-doc-ros2-is-being-retired/19141

This is only removing the menu item pointing to the deprecated content. It's still there with redirects. I'll open a new issue to disable the generation of the site and we can hard code the redirects instead of generating them every night.

Follow up to https://github.com/ros2/ros2_documentation/pull/1108