### PR TITLE
👩‍🌾 Need to run sphinx with C.UTF-8 locale to play nicely with encoding

### DIFF
--- a/_plugins/docs_generator.rb
+++ b/_plugins/docs_generator.rb
@@ -145,7 +145,7 @@ class DocPageGenerator < Jekyll::Generator
     output_path = Pathname.new(File.join(repo_path, '_build'))
     FileUtils.rm_r(output_path) if File.directory? output_path
     FileUtils.makedirs(output_path)
-    command = "python3 -m sphinx -b json -c #{repo_path} #{input_path} #{output_path}"
+    command = "LC_ALL=C.UTF-8 python3 -m sphinx -vvv -b json -c #{repo_path} #{input_path} #{output_path}"
     pid = Kernel.spawn(command)
     Process.wait pid
 


### PR DESCRIPTION
The [buildfarm is failing](https://build.ros.org/job/doc_rosindex/812/) doc_rosindex with:

```terminal
03:21:15 bundle exec jekyll build --verbose --trace -d /tmp/upload_repository --config=_config.yml,index.yml
03:21:15   Logging at level: debug
03:21:16 Configuration file: _config.yml
03:21:16 Configuration file: index.yml
03:21:16          Requiring: /tmp/doc_repository/_plugins/pre_configuration.rb
03:21:16          Requiring: /tmp/doc_repository/_plugins/redcarpet_toc.rb
03:21:16          Requiring: /tmp/doc_repository/_plugins/docs_generator.rb
03:21:16          Requiring: /tmp/doc_repository/_plugins/rosindex_generator.rb
03:21:16          Requiring: /tmp/doc_repository/_plugins/array_filters.rb
03:21:16          Requiring: jekyll-include-cache
03:21:16          Requiring: jekyll-sitemap
03:21:16             Source: /tmp/doc_repository
03:21:16        Destination: /tmp/upload_repository
03:21:16  Incremental build: disabled. Enable with --incremental
03:21:16       Generating... 
03:21:16        EntryFilter: excluded /Makefile
03:21:16        EntryFilter: excluded /node_modules
03:21:16        EntryFilter: excluded /docker
03:21:16        EntryFilter: excluded /Gemfile.lock
03:21:16        EntryFilter: excluded /README.md
03:21:16        EntryFilter: excluded /Gemfile
03:21:16 [1;34mScraping documentation pages from repositories...[0m
03:21:16 Running Sphinx v3.5.3
03:21:16 
03:21:16 Encoding error:
03:21:16 'ascii' codec can't decode byte 0xc2 in position 69: ordinal not in range(128)
```

Running [sphinx](https://build.ros.org/job/_test_jrivero_doc_rosindex/3/console) with `-vvv`give us some hints:

```
...
10:00:02 [app] adding config value: ('gettext_last_translator', 'FULL NAME <EMAIL@ADDRESS>', 'gettext')
10:00:02 [app] adding config value: ('gettext_language_team', 'LANGUAGE <LL@li.org>', 'gettext')
10:00:02 [app] setting up extension: 'sphinx.builders.html'
10:00:02 [app] setting up extension: 'sphinx.builders.latex'
10:00:02 
10:00:02 Traceback (most recent call last):
10:00:02   File "/usr/local/lib/python3.6/dist-packages/sphinx/cmd/build.py", line 279, in build_main
10:00:02     args.tags, args.verbosity, args.jobs, args.keep_going)
10:00:02   File "/usr/local/lib/python3.6/dist-packages/sphinx/application.py", line 241, in __init__
10:00:02     self.setup_extension(extension)
10:00:02   File "/usr/local/lib/python3.6/dist-packages/sphinx/application.py", line 402, in setup_extension
10:00:02     self.registry.load_extension(self, extname)
10:00:02   File "/usr/local/lib/python3.6/dist-packages/sphinx/registry.py", line 417, in load_extension
10:00:02     mod = import_module(extname)
10:00:02   File "/usr/lib/python3.6/importlib/__init__.py", line 126, in import_module
10:00:02     return _bootstrap._gcd_import(name[level:], package, level)
10:00:02   File "<frozen importlib._bootstrap>", line 994, in _gcd_import
10:00:02   File "<frozen importlib._bootstrap>", line 971, in _find_and_load
10:00:02   File "<frozen importlib._bootstrap>", line 955, in _find_and_load_unlocked
10:00:02   File "<frozen importlib._bootstrap>", line 665, in _load_unlocked
10:00:02   File "<frozen importlib._bootstrap_external>", line 678, in exec_module
10:00:02   File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
10:00:02   File "/usr/local/lib/python3.6/dist-packages/sphinx/builders/latex/__init__.py", line 25, in <module>
10:00:02     from sphinx.builders.latex.util import ExtBabel
10:00:02   File "/usr/local/lib/python3.6/dist-packages/sphinx/builders/latex/util.py", line 13, in <module>
10:00:02     from docutils.writers.latex2e import Babel
10:00:02   File "/usr/local/lib/python3.6/dist-packages/docutils/writers/latex2e/__init__.py", line 575, in <module>
10:00:02     for line in fp:
10:00:02   File "/usr/lib/python3.6/encodings/ascii.py", line 26, in decode
10:00:02     return codecs.ascii_decode(input, self.errors)[0]
10:00:02 UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 69: ordinal not in range(128)
```

Something in `sphinx.builders.latex` seems to make the coding to be broken.

The error can reproduced by running locally:
```bash
LC_ALL=C python3 -m sphinx -vvv -b json -c _remotes/ros2 _remotes/ros2/source _remotes/ros2/_build 
```

Not sure if to set up explicitly the `utf-8` locale is the best fix but the whole fix pass in the [buildfarm testing job](https://build.ros.org/job/_test_jrivero_doc_rosindex/4/console). I'm also leaving the `-vvv` which could help to detect other bugs.