### PR TITLE
remove sphinx-tabs

### DIFF
--- a/css/sphinx.css
+++ b/css/sphinx.css
@@ -29,34 +29,3 @@ div.admonition p.admonition-title {
     background-color: rgba(132, 172, 255, 0.4);
     display: block;
 }
-
-/* Deal with sphinx-tabs extension CSS */
-
-.docutils.container {
-    margin-left: initial !important;
-    margin-right: initial !important;
-    padding-left: 10px !important;
-    padding-right: 10px !important;
-    width: initial !important;
-}
-
-.menu.docutils.container {
-    padding-left: 0px !important;
-    padding-right: 0px !important;
-    line-height: initial !important;
-}
-
-.sphinx-tab .highlight,
-.sphinx-tab pre {
-    margin-top: 5px !important;
-    margin-bottom: 5px !important;
-}
-
-.sphinx-tab.segment {
-    font-size: 1em !important;
-}
-
-.docutils.item {
-    margin-bottom: -2px !important;
-    line-height: initial !important;
-}

--- a/docker/image/Dockerfile
+++ b/docker/image/Dockerfile
@@ -53,7 +53,6 @@ RUN apt-get update && \
 RUN gem install bundle
 RUN pip3 install --upgrade setuptools pip
 RUN pip3 install sphinx sphinx-reredirects gitpython
-RUN pip3 install git+https://github.com/hidmic/sphinx-tabs.git@support-json-builder#egg=sphinx-tabs
 
 RUN ln -s `which nodejs` /usr/local/bin/node
 


### PR DESCRIPTION
Partial rollback of #191
This relies on https://github.com/ros2/ros2_documentation/pull/1518

Our fork is out of date and isn't compatible with the new 4.x sphinx