### PR TITLE
make the console output much less verbose for not found repos

### DIFF
--- a/_plugins/rosindex_generator.rb
+++ b/_plugins/rosindex_generator.rb
@@ -717,7 +717,7 @@ class Indexer < Jekyll::Generator
             scrape_version(site, repo, distro, snapshot, vcs)
           end
         else
-          puts (" --- no version for " << repo.name << " instance: " << repo.id << " distro: " << distro).yellow
+          dputs (" --- no version for " << repo.name << " instance: " << repo.id << " distro: " << distro).yellow
         end
       rescue VCSException => e
         @errors[repo.name] << IndexException.new("Could not find version for distro #{distro}: "+e.msg, repo.id)


### PR DESCRIPTION
It should be clear that if it doesn't find specific versions it doesn't find them for the other ones. Move it to debug only.

The can save up to 10 lines of console output per repo which is large.