### PR TITLE
Support GitLab browse & raw URIs

### DIFF
--- a/_plugins/rosindex_generator.rb
+++ b/_plugins/rosindex_generator.rb
@@ -58,6 +58,11 @@ def get_raw_uri(uri_s, type, branch)
     path_split = uri_split[1].rpartition('.')
     repo_name = if path_split[1] == '.' then path_split[0] else path_split[-1] end
     return 'https://raw.githubusercontent.com/%s/%s/%s' % [uri_split[0].sub(/^\//, ''), repo_name, branch]
+  when 'gitlab.com'
+    uri_split = File.split(uri.path)
+    path_split = uri_split[1].rpartition('.')
+    repo_name = if path_split[1] == '.' then path_split[0] else path_split[-1] end
+    return 'https://gitlab.com/%s/%s/-/raw/%s' % [uri_split[0].sub(/^\//, ''), repo_name, branch]
   when 'bitbucket.org'
     uri_split = File.split(uri.path)
     return 'https://bitbucket.org/%s/%s/raw/%s' % [uri_split[0], uri_split[1], branch]
@@ -79,6 +84,11 @@ def get_browse_uri(uri_s, type, branch)
     path_split = uri_split[1].rpartition('.')
     repo_name = if path_split[1] == '.' then path_split[0] else path_split[-1] end
     return 'https://github.com/%s/%s/tree/%s' % [uri_split[0].sub(/^\//, ''), repo_name, branch]
+  when 'gitlab.com'
+    uri_split = File.split(uri.path)
+    path_split = uri_split[1].rpartition('.')
+    repo_name = if path_split[1] == '.' then path_split[0] else path_split[-1] end
+    return 'https://gitlab.com/%s/%s/-/tree/%s' % [uri_split[0].sub(/^\//, ''), repo_name, branch]
   when 'bitbucket.org'
     uri_split = File.split(uri.path)
     return 'https://bitbucket.org/%s/%s/src/%s' % [uri_split[0], uri_split[1], branch]


### PR DESCRIPTION
"Browse Code" links for packages hosted on GitLab are invalid. I couldn't find where raw links are used, but looking at the code they're invalid as well.

For example: https://index.ros.org/p/tracetools/gitlab-ros-tracing-ros2_tracing/#galactic

* "Browse Code" link: https://gitlab.com/ros-tracing/ros2_tracing.git/tracetools
* should be: https://gitlab.com/ros-tracing/ros2_tracing/-/tree/master/tracetools

This PR adds support for GitLab links for browse URIs and raw URIs.

I've manually tested the two functions and they work. They also work fine with GitLab subgroups (e.g. https://gitlab.com/group/subgroup/other-subgroup/repo.git).

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>