### PR TITLE
Move dashing and kinetic to "old" rosdistros.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -92,24 +92,24 @@ index_old_doc_paths: false
 ros2_distros:
   - 'galactic'
   - 'foxy'
-  - 'dashing'
 
 ros_distros:
   - 'noetic'
   - 'melodic'
-  - 'kinetic'
 
 old_ros2_distros:
   - 'ardent'
   - 'bouncy'
   - 'crystal'
   - 'eloquent'
+  - 'dashing'
 
 old_ros_distros:
   - 'lunar'
   - 'jade'
   - 'indigo'
   - 'hydro'
+  - 'kinetic'
 
 # package list page
 packages_per_page: 200


### PR DESCRIPTION
I came to update Dashing and saw that Kinetic was still in the active distros list.