### PR TITLE
add humble to index.ros.org

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -90,6 +90,7 @@ index_old_doc_paths: false
 # drop-down list in the distro selector.
 #
 ros2_distros:
+  - 'humble'
   - 'galactic'
   - 'foxy'
   - 'rolling'

--- a/index.html
+++ b/index.html
@@ -73,6 +73,9 @@ layout: default
     <p>
       <a href="https://docs.ros.org/en/galactic/Releases/Release-Galactic-Geochelone.html">ROS 2 Galactic</a>
     </p>
+    <p>
+      <a href="https://docs.ros.org/en/humble/Releases/Release-Humble-Hawksbill.html">ROS 2 Humble</a>
+    </p>
     <h2>Development Distribution</h2>
     <p>
       <a href="http://docs.ros.org/en/rolling/Releases/Release-Rolling-Ridley.html">ROS 2 Rolling</a>


### PR DESCRIPTION
It is a little early for adding it to the list of active distros, but I figured it's better to have it there early than forget to add it later now that we're in the RC.

