### PR TITLE
fix link for ROS 2 auto generated docs

### DIFF
--- a/_plugins/rosindex_generator.rb
+++ b/_plugins/rosindex_generator.rb
@@ -506,9 +506,11 @@ class Indexer < Jekyll::Generator
       end
 
       if $ros_distros.include? distro
+        # ROS 1
         docs_uri = "http://docs.ros.org/#{DEFAULT_LANGUAGE_PREFIX}/#{distro}/api/#{package_name}/html/"
       else
-        docs_uri = "http://docs.ros2.org/#{distro}/api/#{package_name}/"
+        # ROS 2
+        docs_uri = "http://docs.ros.org/#{DEFAULT_LANGUAGE_PREFIX}/#{distro}/p/#{package_name}"
       end
 
       # try to acquire information on the CI status of the package


### PR DESCRIPTION
The jobs are turning over. This will make the results accessible to everyone.

I was worried that we'd break the old docs.ros2.org links. But they're already broken eg: https://docs.ros2.org/rolling/api/rclcpp/ linked from https://index.ros.org/p/rclcpp/#rolling is 404. So https://docs.ros.org/en/rolling/p/rclcpp/ is strictly better despite not being fully fleshed out.