### PR TITLE
Switch to use GA4 tags from old google analytics ID

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,7 @@ kramdown:
 
 profile: true
 
-google_analytics_property_id: 'UA-17821189-2'
+google_analytics_tag_id: 'G-EVD5Z6G6NH'
 
 redcarpet:
   extensions:

--- a/_includes/google_analytics.html
+++ b/_includes/google_analytics.html
@@ -1,9 +1,11 @@
+{% if site.google_analytics_tag_id %}
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-EVD5Z6G6NH"></script>
 <script>
-(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
 
-ga('create', '{{site.google_analytics_property_id}}', 'auto');
-ga('send', 'pageview');
+  gtag('config', '{{site.google_analytics_tag_id}}');
 </script>
+{% endif %}


### PR DESCRIPTION
The old trackers are being deprecated we need to move to the new GA4 property.