### PR TITLE
Add iron to active distros

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -90,6 +90,7 @@ index_old_doc_paths: false
 # drop-down list in the distro selector.
 #
 ros2_distros:
+  - 'iron'
   - 'humble'
   - 'foxy'
   - 'rolling'

--- a/_config.yml
+++ b/_config.yml
@@ -90,9 +90,9 @@ index_old_doc_paths: false
 # drop-down list in the distro selector.
 #
 ros2_distros:
-  - 'iron'
-  - 'humble'
   - 'foxy'
+  - 'humble'
+  - 'iron'
   - 'rolling'
 
 ros_distros:

--- a/index.html
+++ b/index.html
@@ -71,10 +71,10 @@ layout: default
       <a href="https://docs.ros.org/en/foxy/Releases/Release-Foxy-Fitzroy.html">ROS 2 Foxy</a>
     </p>
     <p>
-      <a href="https://docs.ros.org/en/galactic/Releases/Release-Galactic-Geochelone.html">ROS 2 Galactic</a>
+      <a href="https://docs.ros.org/en/humble/Releases/Release-Humble-Hawksbill.html">ROS 2 Humble</a>
     </p>
     <p>
-      <a href="https://docs.ros.org/en/humble/Releases/Release-Humble-Hawksbill.html">ROS 2 Humble</a>
+      <a href="https://docs.ros.org/en/iron/Releases/Release-Iron-Irwini.html">ROS 2 Iron</a>
     </p>
     <h2>Development Distribution</h2>
     <p>


### PR DESCRIPTION
This PR:
* Removes `galactic` and adds `iron` under Active distributions in the `index.html`
* Adds `iron` to list of `ros2_distros` in `_config.yml`. I'm assuming this will help index the `iron` version of ROS 2 packages (once the [roc_rosindex](https://build.ros.org/job/doc_rosindex/
) is rerun) but let me know if there's anything else that needs to be updated.

<img width="1025" alt="image" src="https://github.com/ros-infrastructure/rosindex/assets/13482049/01122f0a-194e-4b05-af84-4fce6c4175e9">
