### PR TITLE
Robot stack exchange

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -9,7 +9,7 @@
           <tr>
             <td valign="middle">
                 ROS Resources:
-              <a href="http://wiki.ros.org/">Documentation</a>
+              <a href="http://docs.ros.org/">Documentation</a>
               |
               <a href="http://wiki.ros.org/Support">Support</a>
               |

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -17,7 +17,7 @@
               |
               <a href="http://status.ros.org/">Service Status</a>
               |
-              <a href="http://answers.ros.org/">Q&A answers.ros.org</a>
+              <a href="https://robotics.stackexchange.com/">Robotics Stack Exchange</a>
             </td>
           </tr>
         </table> <!-- topnav-table -->

--- a/_includes/package_body.html
+++ b/_includes/package_body.html
@@ -433,11 +433,11 @@ Assumes distro and package are defined
   <div class="tab-pane" id="{{distro}}-questions">
     <div class="panel panel-default">
       <div class="panel-heading">
-        <h3 class="panel-title">Recent questions tagged <kbd>{{package.name}}</kbd> at <strong><a href="https://answers.ros.org" target="_blank">answers.ros.org</a></strong></h3>
+        <h3 class="panel-title">Recent questions tagged <kbd>{{package.name}}</kbd> at <strong><a href="https://robotics.stackexchange.com/" target="_blank">Robotics Stack Exchange</a></strong></h3>
       </div>
       <div id="{{distro}}-question-list" class="panel-body" style="display: none;"></div>
       <div id="{{distro}}-no-question-list" class="panel-body" style="display: none;">
-        <p>No questions yet, you can ask one <a href="https://answers.ros.org/questions/ask/?tags={{package.name}},{{distro}}">here</a>.</p>
+        <p>No questions yet, you can ask one <a href="https://robotics.stackexchange.com/questions/tagged/{{package.name}}+{{distro}}">here</a>.</p>
       </div>
       <div id="{{distro}}-get-question-fail" class="panel-body alert alert-warning" style="display: none;">
         <p>Failed to get question list, you can ticket an issue <a href="https://github.com/ros2/rosindex/issues/new" target="_blank" class="alert-link">here</a> </p>
@@ -450,8 +450,8 @@ Assumes distro and package are defined
 
 <script id="{{distro}}-question-list-template" type="text/html">
   <p>
-    Browse <a href="https://answers.ros.org/questions/scope:all/sort:activity-desc/tags:{{package.name}}/page:1/">recent questions</a>
-    or see the <a href="https://answers.ros.org/questions/scope:all/sort:votes-desc/tags:{{package.name}}/page:1/">higest voted ones</a>.
+    Browse <a href="https://robotics.stackexchange.com/questions/tagged/{{package.name}}?tab=Newest">recent questions</a>
+    or see the <a href="https://robotics.stackexchange.com/questions/tagged/{{package.name}}?tab=Votes">higest voted ones</a>.
   </p>
   {% raw %}
   <div class="list-group">

--- a/_includes/package_body.html
+++ b/_includes/package_body.html
@@ -466,7 +466,7 @@ Assumes distro and package are defined
         {{&description}}
       </div>
       <a class="question-description-toggle" id="question-description-{{id}}-toggle">Show more</a>
-      <a class="question-link"  target="_blank" href="{{link}}">View on answers.ros.org</a>
+      <a class="question-link"  target="_blank" href="{{link}}">View on Robotics Stack Exchange</a>
     </div>
     {{/questions}}
   </div>
@@ -491,7 +491,7 @@ jQuery.browser = {};
 })();
 jQuery(function() {
     jQuery.getFeed({
-        url: "https://answers.ros.org/feeds/rss/?tags={{package.name}}",
+        url: "https://robotics.stackexchange.com/feeds/tag/{{package.name}}",
         success: function(feed) {
             if (feed.items.length > 0) {
               var converter = new showdown.Converter();

--- a/index.html
+++ b/index.html
@@ -74,7 +74,7 @@ layout: default
       <a href="https://discourse.ros.org/">ROS Discourse</a>
     </p>
     <p>
-      <a href="https://answers.ros.org/questions/">ROS Answers</a>
+      <a href="https://robotics.stackexchange.com/">Robotics Stack Exchange</a>
     </p>
     <p>
       <a href="https://www.ros.org/">ros.org</a>


### PR DESCRIPTION
This is the first step towards having ROS Index point to Robotics Stack Exchange instead of answers.ros.org. 

After some cajoling, and enabling cross-site scripting locally with ths [Chrome Extension](https://chromewebstore.google.com/detail/allow-cors-access-control/lhobafahddgcelffkeicbaginigeejlf), I was able to quickly test these changes locally. 

There remains a fairly complex JS section on the package level pages  that is still pulling from ROS Answers. I need to refactor that section of code to pull from Robotics Stack Exchange.. I'm still trying to figure out how to make the code / build / debug loop for ROS Index not be completely onerous. I intend to send a second pull request with these changes later on. 