### PR TITLE
point documentation link to docs.ros.org

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -9,7 +9,7 @@
           <tr>
             <td valign="middle">
                 ROS Resources:
-              <a href="http://wiki.ros.org/">Documentation</a>
+              <a href="http://docs.ros.org/">Documentation</a>
               |
               <a href="http://wiki.ros.org/Support">Support</a>
               |


### PR DESCRIPTION
Landing page at docs.ros.org will route you appropriately to the distro of your choosing - including ROS 1 if you so wish.