### PR TITLE
restore gitpython needed for upload

### DIFF
--- a/docker/image/Dockerfile
+++ b/docker/image/Dockerfile
@@ -39,6 +39,9 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 RUN gem install bundle
+RUN pip3 install --upgrade setuptools pip
+# For uploading
+RUN pip3 install gitpython
 
 RUN ln -s `which nodejs` /usr/local/bin/node
 

--- a/docker/image/Dockerfile
+++ b/docker/image/Dockerfile
@@ -32,6 +32,7 @@ RUN apt-get update && \
         openssl \
         pandoc \
         pkg-config \
+        python3-pip \
         python3-vcstool \
         ruby \
         ruby-dev \


### PR DESCRIPTION
Truly the last step failed https://build.ros.org/job/doc_rosindex/1851/

```
18:33:17 
18:33:17  
18:33:17                     done in 14882.704 seconds.
18:33:17  Auto-regeneration: disabled. Use --watch to enable.
18:33:17 make: Leaving directory '/tmp/doc_repository'
18:33:18 Traceback (most recent call last):
18:33:18   File "/usr/local/bin/git_add_files", line 4, in <module>
18:33:18     import git
18:33:18 ModuleNotFoundError: No module named 'git'
18:33:18 Build step 'Execute shell' marked build as failure
18:33:19 Build did not succeed and the project is configured to only push after a successful build, so no pushing will occur.
18:33:19 Finished: FAILURE
```