### PR TITLE
stop implictly adding repos using distro matches (#327)

### DIFF
--- a/_plugins/rosindex_generator.rb
+++ b/_plugins/rosindex_generator.rb
@@ -1082,7 +1082,7 @@ class Indexer < Jekyll::Generator
                       end
 
                       # get the tracks file
-                      ['master','bloom', 'main'].each do |branch_name|
+                      ['master','bloom'].each do |branch_name|
                         branch, _ = release_vcs.get_version(branch_name)
 
                         if branch.nil? then next end

--- a/_plugins/rosindex_generator.rb
+++ b/_plugins/rosindex_generator.rb
@@ -711,7 +711,7 @@ class Indexer < Jekyll::Generator
         unless explicit_version.nil?
           dputs (" Looking for explicit version #{explicit_version}").green
         end
-        version, snapshot.version = vcs.get_version(distro, explicit_version)
+        version, snapshot.version = vcs.get_version(explicit_version)
 
         # scrape the data (packages etc)
         if version
@@ -1082,7 +1082,7 @@ class Indexer < Jekyll::Generator
                       end
 
                       # get the tracks file
-                      ['master','bloom'].each do |branch_name|
+                      ['master','bloom', 'main'].each do |branch_name|
                         branch, _ = release_vcs.get_version(branch_name)
 
                         if branch.nil? then next end

--- a/_ruby_libs/rosindex.rb
+++ b/_ruby_libs/rosindex.rb
@@ -79,7 +79,7 @@ class Repo < Liquid::Drop
 
     # hash distro -> RepoSnapshot
     # each entry in this hash represents the preferred version for a given distro in this repo
-    @snapshots = Hash[$all_distros.collect { |d| [d, RepoSnapshot.new(nil, d, false, false)] }]
+    @snapshots = {}
 
     # tags from all versions
     @tags = []

--- a/_ruby_libs/vcs.rb
+++ b/_ruby_libs/vcs.rb
@@ -146,7 +146,7 @@ class GIT < VCS
     return @r.last_commit.time.strftime('%F')
   end
 
-  def get_version(distro, explicit_version = nil)
+  def get_version(explicit_version)
 
     # remote head
     if explicit_version == 'REMOTE_HEAD'
@@ -205,15 +205,9 @@ class GIT < VCS
       # NOTE: no longer need to check remote names #if branch.remote_name != repo.id then next end
 
       #dputs " -- examining branch " << branch.name << " trunc: " << branch_name << " from remote: " << branch.remote_name
-      #puts " - should have " << distro << " version " << explicit_version.to_s
 
-      # save the branch as the version if it matches either the explicit
-      # version or the distro name
-      if explicit_version
-        if branch_name == explicit_version
-          return branch, branch_name
-        end
-      elsif branch_name.include? distro
+      # save the branch as the version if it matches the explicit version
+      if explicit_version && branch_name == explicit_version
         return branch, branch_name
       end
     end
@@ -222,12 +216,8 @@ class GIT < VCS
     @r.tags.each do |tag|
       tag_name = tag.name
 
-      # save the tag if it matches either the explicit version or the distro name
-      if explicit_version
-        if tag_name == explicit_version
-          return tag, tag_name
-        end
-      elsif tag_name.include? distro
+      # save the tag if it matches the explicit version
+      if explicit_version && tag_name == explicit_version
         return tag, tag_name
       end
     end
@@ -289,7 +279,7 @@ class HG < VCS
     end
   end
 
-  def get_version(distro, explicit_version = nil)
+  def get_version(explicit_version)
     # get remote head
     if explicit_version == 'REMOTE_HEAD'
       return 'default', 'default'
@@ -300,13 +290,8 @@ class HG < VCS
       # get the branch shortname
       branch_name = branch.name
 
-      # save the branch as the version if it matches either the explicit
-      # version or the distro name
-      if explicit_version
-        if branch_name == explicit_version
-          return branch.name, branch_name
-        end
-      elsif branch_name.include? distro
+      # save the branch as the version if it matches the explicit version
+      if explicit_version && branch_name == explicit_version
         return branch.name, branch_name
       end
     end
@@ -315,12 +300,8 @@ class HG < VCS
     @r.tags.all.each do |tag|
       tag_name = tag.name
 
-      # save the tag if it matches either the explicit version or the distro name
-      if explicit_version
-        if tag_name == explicit_version
-          return tag.name, tag_name
-        end
-      elsif tag_name.include? distro
+      # save the tag if it matches the explicit version
+      if explicit_version && tag_name == explicit_version
         return tag.name, tag_name
       end
     end
@@ -354,7 +335,7 @@ class GITSVN < GIT
     super(local_path, uri)
   end
 
-  def get_version(distro, explicit_version = nil)
+  def get_version(explicit_version)
     if explicit_version == 'REMOTE_HEAD'
       return @r.branches['master'], 'master' # super(distro, explicit_version = 'master')
     else


### PR DESCRIPTION
As discussed in #327, we want to move away from aggressively trying to locate possible releases of ros packages, based on finding a branch name that contains a distro name, and instead rely on rosdistro for repos.

One minor drive-by change: while investigating some earlier problems, I found release repos that had changed their branch name to main, so I added that to the release repo search.

I've run the index using these changes, and uploaded (temporarily) to http://test1.rosdabbler.com
