### PR TITLE
Add slash to CI integration http requests (fixes #332)

### DIFF
--- a/_plugins/rosindex_generator.rb
+++ b/_plugins/rosindex_generator.rb
@@ -228,7 +228,7 @@ class Indexer < Jekyll::Generator
 
   def get_ci_data(distro, package_name, repo_name)
     ci_data = Hash.new
-    manifest_url = "#{DEFAULT_LANGUAGE_PREFIX}/#{distro}/api/#{package_name}/manifest.yaml"
+    manifest_url = "/#{DEFAULT_LANGUAGE_PREFIX}/#{distro}/api/#{package_name}/manifest.yaml"
     manifest_response = Net::HTTP.get_response('docs.ros.org', manifest_url)
     if manifest_response.code != '200'
       ci_data['tooltip'] = 'No CI information available for this package.'
@@ -249,7 +249,7 @@ class Indexer < Jekyll::Generator
     end
     ci_data['job_url'] = manifest_yaml['devel_jobs'][0]
     # get additional test information if available
-    results_url = "#{DEFAULT_LANGUAGE_PREFIX}/#{distro}/devel_jobs/#{repo_name}/results.yaml"
+    results_url = "/#{DEFAULT_LANGUAGE_PREFIX}/#{distro}/devel_jobs/#{repo_name}/results.yaml"
     results_response = Net::HTTP.get_response('docs.ros.org', results_url)
     if results_response.code != '200'
       ci_data['tooltip'] = "Latest build information: " + ci_data['timestamp'] + "\n" \


### PR DESCRIPTION
There must have been a change in the underlying ruby code that it now requires preceding slashes in the path of URLs.

A rosindex run with this change is available at: http://test2.rosdabbler.com
