### PR TITLE
404 Page handling w/ issue form (#362)

### DIFF
--- a/.github/ISSUE_TEMPLATE/form404.yml
+++ b/.github/ISSUE_TEMPLATE/form404.yml
@@ -1,0 +1,32 @@
+name: Broken Link Report
+description: File a broken link report
+title: "Broken Link:"
+labels: ["bug"]
+projects: ["ros-infrastructure/rosindex"]
+body:
+
+  - type: input
+    id: 404page
+    attributes:
+      label: 404 Page URL
+      description: Page that you were trying to access
+      placeholder: https://index.ros.org/404
+    validations:
+      required: true
+
+  - type: input
+    id: referer
+    attributes:
+      label: Referrer URL
+      description: Page that you were on when you clicked the link and got a 404
+      placeholder: https://index.ros.org/
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      placeholder: If any additional information is needed, please provide it here.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/form404.yml
+++ b/.github/ISSUE_TEMPLATE/form404.yml
@@ -9,8 +9,8 @@ body:
     id: 404page
     attributes:
       label: 404 Page URL
-      description: If this isn't autodetected it means you have to fill it in yourself
-      placeholder: FAILED TO AUTOMATICALLY DETECT 404 PAGE URL PLEASE FILL
+      description: Enter the url of the page that doesn't exist
+      placeholder: Failed to automatically detect 404 page. Please enter url here.
     validations:
       required: true
 
@@ -18,8 +18,8 @@ body:
     id: referer
     attributes:
       label: Referrer URL
-      description: If this isn't autodetected it means you have to fill it in yourself
-      placeholder: FAILED TO AUTOMATICALLY DETECT REFERRER URL PLEASE FILL
+      description: Enter the URL of the referring page which has the wrong link.
+      placeholder: Automatic detection of the referrer page failed, please enter it here.
     validations:
       required: true
 
@@ -27,6 +27,6 @@ body:
     id: description
     attributes:
       label: Description
-      placeholder: If any additional information is needed, please provide it here.
+      placeholder: Please describe where the link is that you followed if it might not be obvious on the referring page. If any additional information is needed, please provide it here too.
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/form404.yml
+++ b/.github/ISSUE_TEMPLATE/form404.yml
@@ -9,8 +9,8 @@ body:
     id: 404page
     attributes:
       label: 404 Page URL
-      description: Page that you were trying to access
-      placeholder: https://index.ros.org/404
+      description: If this isn't autodetected it means you have to fill it in yourself
+      placeholder: FAILED TO AUTOMATICALLY DETECT 404 PAGE URL PLEASE FILL
     validations:
       required: true
 
@@ -18,8 +18,8 @@ body:
     id: referer
     attributes:
       label: Referrer URL
-      description: Page that you were on when you clicked the link and got a 404
-      placeholder: https://index.ros.org/
+      description: If this isn't autodetected it means you have to fill it in yourself
+      placeholder: FAILED TO AUTOMATICALLY DETECT REFERRER URL PLEASE FILL
     validations:
       required: true
 

--- a/404.html
+++ b/404.html
@@ -49,13 +49,13 @@ title: "404: Not Found"
       // Get current url
       var currentUrl = window.location.href;
       if (!currentUrl) {
-        currentUrl = "URL+not+available";
+        currentUrl = "";
       }
 
       // Get the url that brought us here
       var referrerUrl = document.referrer;
       if (!referrerUrl) {
-        referrerUrl = "Referrer+URL+not+available";
+        referrerUrl = "";
       }
 
       // Encode the urls

--- a/404.html
+++ b/404.html
@@ -30,7 +30,7 @@ title: "404: Not Found"
         </div>
         <div class="row">
           <div class="col-xs-offset-3 col-xs-6 text-center">
-            <a target="_blank" href="https://github.com/ros-infrastructure/rosindex/issues/new?title=Broken%20Link:%20" class="btn btn-sm btn-default btn-block">Report Broken Link</a>
+            <a id="github_issue_link" target="_blank" href="" class="btn btn-sm btn-default btn-block">Report Broken Link</a>
           </div>
         </div>
         <div class="row">
@@ -42,7 +42,41 @@ title: "404: Not Found"
 </div>
 
 <script>
-$(function () {
-    // TODO add url to the report button
-  };)
+  $(function () {
+    function updateGitHref() {
+      let githubLink = "https://github.com/ros-infrastructure/rosindex/issues/new?labels=bug&template=form404.yml";
+
+      // Get current url
+      var currentUrl = window.location.href;
+      if (!currentUrl) {
+        currentUrl = "URL+not+available";
+      }
+
+      // Get the url that brought us here
+      var referrerUrl = document.referrer;
+      if (!referrerUrl) {
+        referrerUrl = "Referrer+URL+not+available";
+      }
+
+      // Encode the urls
+      var title = "title=Broken+Link:" + encodeURIComponent(currentUrl);
+      var currentUrl_encoded = "404page=" + encodeURIComponent(currentUrl);
+      var referrerUrl_encoded = "referer=" + encodeURIComponent(referrerUrl);
+
+      // Update the href
+      githubLink += "&" + title + "&" + currentUrl_encoded + "&" + referrerUrl_encoded;
+
+      // Set the href
+      var githubIssueLink = $("#github_issue_link");
+      if (!githubIssueLink.length) {
+        console.error("Github issue link element is not available");
+        return;
+      }
+      githubIssueLink.attr("href", githubLink);
+    }
+
+    // Update the href
+    updateGitHref();
+
+  });
 </script>


### PR DESCRIPTION
This pull request introduces the updateGitHref() function. It is responsible for dynamically updating a GitHub issue link with relevant information.

**Referrer URL Handling:** It's worth noting that accessing document.referrer might result in an empty value if the user navigated directly to the page or if the browser's privacy settings restrict referrer information. The function handles such scenarios, providing a default value to prevent errors.

Issue: [#362](https://github.com/ros-infrastructure/rosindex/issues/362) from @tfoote 