### PR TITLE
[WIP] Direct link to local tutorials

### DIFF
--- a/_includes/package_body.html
+++ b/_includes/package_body.html
@@ -219,7 +219,15 @@ Assumes distro and package are defined
         <h3 class="panel-title">Source Tutorials</h3>
       </div>
       <div class="panel-body">
-        <em>Not currently indexed.</em>
+        <a class="{{list_group_class}}"
+           target="_blank"
+           href="{{ package.data.docs_uri }}/tutorials.html"
+           title="View API tutorials on docs.ros.org"
+           {% unless package.snapshot.documented %}disabled{% endunless %}>
+             <span style="margin-right: 5px;" class="glyphicon glyphicon-file"></span>
+             {%if hide_link_labels%}<br>{%endif%}
+             Source Tuorials
+        </a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
This pull request is aimed at replacing at both #295 and #93, by showing immediate access to tutorials to the user which are connected through the docs. I interpret `Source Tutorials` to be any tutorials aligned with the orignal documentation of the package so, a Tutorials Section of the documentation.

There are multiple packages which have tutorials in their docs, which clients can use on site (which makes sense IMO) - [image_pipeline](https://github.com/ros-perception/image_pipeline) and a growing effort in [geometry2](https://github.com/ros2/geometry2/pull/671). This is a work in a progress pull request as I would like to test the waters to see if this type of stuff could be standardized, becuase if all packages generated documentation (tutorials) in this way instead of something like [these offsite](https://github.com/orgs/ros-perception/repositories?q=tutorial) tutorials, it would be much easier to manage everything. Especially if generating documentation through something like rosdoc2 becomes more prevalent, so I'm going to start there.