### PR TITLE
Fix misalignment of repo name

### DIFF
--- a/_layouts/packages.html
+++ b/_layouts/packages.html
@@ -82,7 +82,6 @@ layout: default
                         <span class="glyphicon glyphicon-none"></span>
                       </td>
                     {% endif %}
-                    </td>
                     <td>
                       <span title="Last commit date" class="label label-default">{{ r.data.last_commit_time }}</span>
                     </td>
@@ -97,7 +96,6 @@ layout: default
                       </div>
                     </td>
                   {% else %}
-                    <td></td>
                     <td></td>
                     <td></td>
                     <td>

--- a/_layouts/repos.html
+++ b/_layouts/repos.html
@@ -96,7 +96,6 @@ layout: default
                   {% else %}
                     <td></td>
                     <td></td>
-                    <td></td>
                     <td>
                       <a class="inactive" href="{{site.baseurl}}/r/{{repo[0]}}">{{ repo[0] }}</a>
                     </td>


### PR DESCRIPTION
Fixes #394 

I'm a little confused as to why this has not been reported before or fixed, it really is a simple issue. But here is the fix, just remove the extra <td></td>