### PR TITLE
Limit venn diagram in stats to recent distros

### DIFF
--- a/_ruby_libs/pages.rb
+++ b/_ruby_libs/pages.rb
@@ -262,14 +262,15 @@ class StatsPage < Jekyll::Page
     self.data['n_errors'] = errors.length
 
     # compute venn diagram model
-    distro_counts = Hash[$all_distros.collect { |d| [d, 0] }]
-    distro_overlaps = Hash[(2..$all_distros.length).flat_map{|n| (0..$all_distros.length-1).to_a.combination(n).to_a}.collect { |s| [s, 0] }]
+    distro_counts = Hash[$recent_distros.collect { |d| [d, 0] }]
+    distro_overlaps = Hash[(2..$recent_distros.length).flat_map{|n| (0..$recent_distros.length-1).to_a.combination(n).to_a}.collect { |s| [s, 0] }]
 
     package_names.each do |package_name, package_instances|
       overlap = []
       #package_instances.snapshots.reject.with_index{|dr, i| dr[1].nil? || dr[1].version.nil? }
       package_instances.snapshots.each.with_index do |s,i|
-        if not s[1].nil? and not s[1].version.nil?
+        puts "s: " + s.to_s
+        if not s[1].nil? and not s[1].version.nil? and not distro_counts[s[0]].nil?
           overlap << i
           distro_counts[s[0]] = distro_counts[s[0]] + 1
         end
@@ -277,7 +278,7 @@ class StatsPage < Jekyll::Page
 
       dputs package_name.to_s + " " + overlap.to_s
 
-      package_overlaps = (2..$all_distros.length).flat_map{|n| overlap.combination(n).to_a}
+      package_overlaps = (2..$recent_distros.length).flat_map{|n| overlap.combination(n).to_a}
 
       package_overlaps.each do |o|
         distro_overlaps[o] = distro_overlaps[o] + 1

--- a/js/venn.js/venn.js
+++ b/js/venn.js/venn.js
@@ -718,9 +718,11 @@
                         }
                     }
                 }
-                arcs.push(arc);
-                arcArea += venn.circleArea(arc.circle.radius, arc.width);
-                p2 = p1;
+                if (arc !== null) {
+                    arcs.push(arc);
+                    arcArea += venn.circleArea(arc.circle.radius, arc.width);
+                    p2 = p1;
+                }
             }
         } else {
             // no intersection points, is either disjoint - or is completely


### PR DESCRIPTION
Fixes #337 

Here is one possible fix to the stats page issue, although this is not my preferred solution. My preferred solution would be to eliminate all distros older than galactic and melodic from rosindex, which has other advantages in eliminating clutter not only here but elsewhere.

But about this fix, assuming you do not want to eliminate older repos. There is a @recent_distros variable defined, but never used in rosindex. We put it to use here, instead of @all_distros.

I also fix a couple of related issues in venn usage that crash me for small data sets, like you get with ```make test-build```. One of these is in venn.js  The proposed fix is actually a backport of [this](https://github.com/benfred/venn.js/commit/1792850b4d0dd732b31e9fa27f68426ca8053cb5) which was added to venn.js shortly after we froze our version. I assume that we froze our version because there were major breaking changes to venn.js after our freeze point that we did not want to implement. Probably we should though update at some point venn.js to incorporate later versions.

The reason I prefer another approach, is that is is really quite interesting in the venn diagram to see the change in available packages from melodic to noetic and beyond. See my [forward version](http://index.rosdabbler.com/stats/) to see what I think is the more interesting venn diagram including melodic. It would also be possible to extend this current PR to allow adding additional distros to venn beyond @recent_distros if you prefer.