### PR TITLE
Use rosindex_logo as favicon

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -18,6 +18,8 @@
     {% else %}
     <link rel="canonical" href="{{ page.url | replace: 'index.html', '' | prepend: site.baseurl | prepend: site.url }}">
     {% endif %}
+    
+    <link rel="icon" sizes="any" type="image/svg+xml" href="/assets/rosindex_logo.svg">
 
     {% if page.css_uris %}
     {% for css_uri in page.css_uris %}


### PR DESCRIPTION
Pretty minor change - just use the existing logo image as the favicon.
