### PR TITLE
Stop failing with small package count

### DIFF
--- a/_ruby_libs/lunr.rb
+++ b/_ruby_libs/lunr.rb
@@ -16,6 +16,7 @@ def precompile_lunr_index(site, index, ref, fields, output_dir, shard_count = 1)
   FileUtils.mkdir_p(site.dest) unless File.directory?(site.dest)
   FileUtils.mkdir_p(output_dirpath) unless File.directory?(output_dirpath)
   shard_size = index.length / shard_count
+  if shard_size == 0 then shard_size = 1 end
 
   Enumerator.new do |enum| 
     shards = index.each_slice(shard_size).with_index.collect do |index_slice, i|


### PR DESCRIPTION
This is a minor that mostly affects debugging.

If you limit the number of repos, but fail to change the shard count, then the shard size rounds down to zero and fails. This prevents that.