### PR TITLE
Restore inadvertently removed prettify.css, rename to current usage

### DIFF
--- a/_includes/repo_summary.html
+++ b/_includes/repo_summary.html
@@ -2,7 +2,7 @@
 - repo
 - snapshot
 {% endcomment %}
-
+  <link rel="stylesheet" href="{{ "/css/ci-status.css" | prepend: site.baseurl }}">
   <table class="table table-condensed">
     <tr>
       <td style="width:100px;" class="text-right"><b>Checkout URI</b></td>

--- a/css/ci-status.css
+++ b/css/ci-status.css
@@ -1,0 +1,13 @@
+td.ci-status{position: absolute}
+td.ci-status button.dropdown-toggle{font-size: 75%; padding: .3em .6em .4em;border: 0}
+td.ci-status button.ci-result-success{background-color:#1f8c22}
+td.ci-status button.ci-result-failure{background-color:#ff4136}
+td.ci-status button.ci-result-unstable{background-color:#ff851b}
+td.ci-status a.ci-result-success{background-color:#1f8c22}
+td.ci-status a.ci-result-failure{background-color:#ff4136}
+td.ci-status a.ci-result-unstable{background-color:#ff851b}
+td.ci-status li.ci-result-success  span{color: #1f8c22}
+td.ci-status li.ci-result-failure  span{color: #ff4136}
+td.ci-status li.ci-result-unstable span{color: #ff851b}
+td.ci-status li.ci-build-info span.caret{margin: 0 3px 0 5px}
+td.ci-status li.ci-build-info span{padding-left: 10px}


### PR DESCRIPTION
This restores prettify.css that was inadvertently removed in an earlier PR, and renames it to properly reflect its usage. It has nothing to do with prettify.

prettify.js was also removed earlier, but I could find no use for that. It has also been discontinued by the owner (Google).