### PR TITLE
Remove inadvertent extra hyphen at top

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -39,7 +39,7 @@
 
     <script type="text/javascript" src={{ "/js/jquery.js" | prepend: site.baseurl }}></script>
     <script src={{ "/bootstrap/js/bootstrap.min.js" | prepend: site.baseurl }} type="text/javascript"></script>
-    <script src={{ "/js/jquery-cookie.js" | prepend: site.baseurl }} type="text/javascript"></script>-
+    <script src={{ "/js/jquery-cookie.js" | prepend: site.baseurl }} type="text/javascript"></script>
     {% include_cached google_analytics.html %}
     <script type="text/javascript" src={{ "/js/toc.js" | prepend: site.baseurl }}></script>
 


### PR DESCRIPTION
Another oops by me. This extra "-" snuck into one of my changed lines, resulting in extra space at the top of the website.