### PR TITLE
shard packages by distro

### DIFF
--- a/_ruby_libs/lunr.rb
+++ b/_ruby_libs/lunr.rb
@@ -3,7 +3,7 @@ require 'fileutils'
 require 'json'
 require_relative './common'
 
-def precompile_lunr_index(site, index, ref, fields, output_dir, shard_count = 1)
+def precompile_lunr_index(site, index, ref, fields, output_dir, shard_names)
   build_index_cmd = File.join(
     site.source, 'node_modules',
     'lunr-index-build', 'bin',
@@ -15,17 +15,16 @@ def precompile_lunr_index(site, index, ref, fields, output_dir, shard_count = 1)
   output_dirpath = File.join(site.dest, output_dir)
   FileUtils.mkdir_p(site.dest) unless File.directory?(site.dest)
   FileUtils.mkdir_p(output_dirpath) unless File.directory?(output_dirpath)
-  shard_size = index.length / shard_count
-  if shard_size == 0 then shard_size = 1 end
 
   Enumerator.new do |enum| 
-    shards = index.each_slice(shard_size).with_index.collect do |index_slice, i|
-      dputs("Building lunr index shard #{i}...")
-      index_filename = "index.#{i}.json"
-      data_filename = "data.#{i}.json"
+    shards = []
+    shard_names.each do |name|
+      dputs("Building lunr index shard #{name}...")
+      index_filename = "index.#{name}.json"
+      data_filename = "data.#{name}.json"
       data_filepath = File.join(output_dirpath, data_filename)
       File.open(data_filepath, 'w') do |data_file|
-        data_file.write(JSON.generate(index_slice))
+        data_file.write(JSON.generate(index[name]))
       end
       enum.yield SearchIndexFile.new(site, site.dest, output_dir, data_filename)
       dputs("Index data written to #{data_filename}.")
@@ -35,7 +34,7 @@ def precompile_lunr_index(site, index, ref, fields, output_dir, shard_count = 1)
       Process.waitpid(pid)
       enum.yield SearchIndexFile.new(site, site.dest, output_dir, index_filename)
       dputs("Index written to #{output_dir}/#{index_filename}.")
-      {:index => index_filename, :data => data_filename}
+      shards << {:index => index_filename, :data => data_filename}
     end
     shards_filename = "shards.json"
     shards_filepath = File.join(output_dirpath, shards_filename)


### PR DESCRIPTION
This PR is the first step in implementing a Tabulator-based package list and search as discussed in #415. It switches the index shards for packages from numbered to per distro. This is because the proposed Tabulator-based tables will present package lists per-distro, not combined.

There should be no visible impact on the existing layout or usage of rosindex with this change. The change is now implemented in https://index.rosdabbler.com along with #432. The goal we are aiming at is shown in https://devindex.rosdabbler.com.