### PR TITLE
Add a Tabulator-based combined package search and list

### DIFF
--- a/_layouts/noscroll-default.html
+++ b/_layouts/noscroll-default.html
@@ -39,19 +39,19 @@
 
     <script type="text/javascript" src={{ "/js/jquery.js" | prepend: site.baseurl }}></script>
     <script src={{ "/bootstrap/js/bootstrap.min.js" | prepend: site.baseurl }} type="text/javascript"></script>
-    <script src={{ "/js/jquery-cookie.js" | prepend: site.baseurl }} type="text/javascript"></script>-
+    <script src={{ "/js/jquery-cookie.js" | prepend: site.baseurl }} type="text/javascript"></script>
     {% include_cached google_analytics.html %}
     <script type="text/javascript" src={{ "/js/toc.js" | prepend: site.baseurl }}></script>
 
     <script src={{ "/js/distro_switch.js" | prepend: site.baseurl }}></script>
   </head>
 
-  <body>
+  <body style="height: 100vh;">
 
     {% include_cached header.html %}
 
-    <div class="page-content">
-      <div class="wrapper">
+    <div class="page-content" style="height: var(--content-height);">
+      <div class="wrapper" style="height:100%;">
         {{ content }}
       </div>
     </div>

--- a/_layouts/search_packages.html
+++ b/_layouts/search_packages.html
@@ -1,0 +1,271 @@
+---
+layout: noscroll-default
+---
+<div class="container-fluid" style="padding-top:10px; height:100%;">
+  <div class="container-fluid" style="height:100%;">
+    <div class="row" style="height:var(--distro-height);">
+      {% include distro_switch.html %}
+    </div>
+    <div class="row" style="height:var(--search-height);">
+      <div class="panel panel-default" style="height:100%;">
+        <div class="panel-heading" style="height:100%;">
+          <div class="row" style="height:100%;">
+            <div class="col-xs-6">
+              <div class="input-group">
+                <span class="input-group-addon">
+                  <input type="checkbox" id="search-enable-box"/>
+                  <span class="hidden-xs"> Enable search </span>
+                </span>
+                <input id="search-query" type="text" class="form-control"
+                        autocomplete="off" placeholder="Search packages">
+                <span class="input-group-btn">
+                  <button id="search-button" title="Search packages" class="btn btn-default">
+                    <span class="glyphicon glyphicon-search"></span>
+                  </button>
+                </span>
+              </div>
+            </div>
+            <div class="col-xs-6">
+              <p style="line-height:35px"><span class="hidden-xs">Showing </span>
+                <span id="table-filtered-count">0</span> of
+                <span id="table-unfiltered-count">0</span> packages
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="row" style="height:calc(100% - var(--search-height) - var(--distro-height))">
+      <div id="packages-table"></div>
+    </div>
+  </div>
+</div>
+
+<!-- See https://github.com/olifolkerd/tabulator/issues/4419 for issue with Tabulator post-5.6.0 -->
+<link href="https://cdn.jsdelivr.net/npm/tabulator-tables@6.3.0/dist/css/tabulator.min.css" rel="stylesheet">
+<!-- <script src={{ "/js/tabulator.js" | prepend: site.baseurl }}></script> -->
+<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/tabulator-tables@6.3.0/dist/js/tabulator.min.js"></script>
+<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/luxon@3.5.0/build/global/luxon.min.js"></script>
+<script src="{{site.baseurl}}/js/lunr.js" type="text/javascript" charset="utf-8"></script>
+<script type="text/javascript">
+  var gData_promises = {};
+  var gIndex_promises = {};
+  var gTable = null;
+  var gDistro = "{{ site.distros[0] }}";
+
+  function addFilter(table, field, type, value) {
+    // Add a new table filter, removing existing
+    removeFilterByField(table, field);
+    table.addFilter(field, type, value);
+  }
+
+  function removeFilterByField(table, field) {
+    // remove all filters on a specified field, if any
+    for (const existingFilter of table.getFilters()) {
+      if ('field' in existingFilter && existingFilter['field'] == field) {
+        table.removeFilter(existingFilter.field, existingFilter.type, existingFilter.value);
+      }
+    }
+  }
+
+  function getData(distro) {
+    // start and return a promise to get distro json data
+    if (distro in gData_promises) {
+      return gData_promises[distro];
+    }
+    gData_promises[distro] =
+      fetch(`{{site.baseurl}}/search/packages/data.${distro}.json`)
+        .then((response) => response.json());
+
+    return gData_promises[distro];
+  }
+
+  function getIndex(distro) {
+    console.log(`getIndex for ${distro}`);
+    // start and return a promise to get distro json index
+    if (distro in gIndex_promises) {
+      return gIndex_promises[distro];
+    }
+    gIndex_promises[distro] =
+      fetch(`{{site.baseurl}}/search/packages/index.${distro}.json`)
+        .then((response) => response.json())
+        .then((indexData) => {
+          return lunr.Index.load(indexData);
+        });
+
+    return gIndex_promises[distro];
+  }
+
+  function getWindowSearchQuery() {
+    return new URL(window.location.toString()).searchParams.get('pkgs');
+  }
+
+  // Populate the search input with querystring parameter
+  function setWindowSearchQuery(query) {
+    var url = new URL(window.location.toString());
+    url.searchParams.set('pkgs', query);
+    window.history.pushState({}, '', url);
+  }
+
+  function copySearchQueryToUI() {
+    var query = getWindowSearchQuery() || '';
+    $('#search-query').val(query);
+    $("#search-enable-box").prop("checked", !!query);
+  }
+
+  function copyUIToSearchQuery() {
+    if ($("#search-enable-box").prop("checked")) {
+      setWindowSearchQuery($('#search-query').val());
+    } else {
+      setWindowSearchQuery('');
+    }
+  }
+
+  // Returns a promise resolving to a search array of id hits.
+  function getSearchArray(distro, query) {
+    if (!query) {
+      return Promise.resolve(null);
+    }
+    return getIndex(distro).then(searchIndex => {
+      var searchResults = searchIndex.search(query);
+      searchArray = searchResults.map((result) => parseInt(result.ref));
+      console.log(`Search returned ${searchArray.length} results`);
+      // Tabulator filters don't seem to work with zero entries
+      searchArray = searchArray.length ? searchArray : [-1];
+      return searchArray;
+    });
+  }
+
+  function doSearch(table, distro, query) {
+    console.log(`doSearch query="${query}"`);
+    getSearchArray(distro, query)
+    .then(searchArray => {
+      if (searchArray) {
+        addFilter(table, 'id', 'in', searchArray)
+      } else {
+        removeFilterByField(table, 'id');
+      }
+    })
+  }
+
+  function makeTable(distro, data, searchArray) {
+    const CALENDAR = "\u{1F4C5}";
+    const STAR = "\u2605";
+    const LEFT_ARROW = "\u2B05"
+    const RIGHT_ARROW = "\u27A1"
+
+    var initialFilter = (searchArray === undefined || searchArray === null) ?
+      [] : [{field: 'id', type: 'in', value: searchArray}];
+
+    const table = new Tabulator("#packages-table", {
+      maxHeight:"100%",
+      // height: "400px",
+      data:data, //assign data to table
+      layout:"fitColumns", //fit columns to width of table (optional)
+      rowHeight:30, // Workaround for https://github.com/olifolkerd/tabulator/issues/4419
+      initialFilter: initialFilter,
+      columns:[ //Define Table Columns
+        { title:"Name", field:"url", width:200,
+          formatter:"link", formatterParams:{labelField:"name", urlPrefix:"{{site.baseurl}}"}},
+        { title:"Description", field:"description", minWidth:300},
+        { title:STAR, field:"released", width:40, formatter:"tickCross", headerTooltip:"release status", hozAlign:"center",
+          formatterParams: {allowTruthy: true, allowEmpty: true}},
+        { title:CALENDAR, field: "last_commit_time", width:80, headerHozAlign:"center", headerTooltip:"last commit date",
+          sorter:"date", sorterParams:{format:"yyyy-MM-dd"}},
+        { title:LEFT_ARROW, field:"pkg_deps", width:40, headerTooltip:"package dependency count"},
+        { title:RIGHT_ARROW, field:"dependants", width:40, headerTooltip:"package used by count"},
+        { title:"Authors", field:"authors", width:120},
+        { title:"Maintainers", field:"maintainers", width:120},
+        { title:"Repo", field:"repo_name", width:100,
+          formatter:"link", formatterParams:{labelField:"repo_name", url:(cell) =>
+          { return `{{site.baseurl}}/r/${cell.getValue()}/#${distro}`}}},
+        { title:"Org", field:"org", width:100},
+      ],
+    });
+    return table;
+  }
+
+  // Returns a promise that resolves to a Tabulator table
+  function showTable(distro, query) {
+    console.log(`showTable distro: ${distro}, query: ${query}`);
+    var searchPromise = query ? getSearchArray(distro, query) : Promise.resolve(null);
+    return Promise.all([getData(distro), searchPromise]).then(values => {
+      var data = values[0];
+      var searchArray = values[1];
+      const table = makeTable(distro, data, searchArray);
+      $("#table-filtered-count").text(data.length);
+      $("#table-unfiltered-count").text(data.length);
+      table.on("dataFiltered", (filters, rows) => {
+        $("#table-filtered-count").text(rows.length);
+        $("#table-unfiltered-count").text(table.getDataCount());
+      });
+      table.on("tableBuilt", () => {
+        $("#table-filtered-count").text(table.getDataCount('active'));
+        $("#table-unfiltered-count").text(table.getDataCount());
+      });
+      return table;
+    });
+  }
+
+  $(function() {
+    console.log('document ready');
+    copySearchQueryToUI();
+    gDistro = setupDistroSwitch("{{ site.distros[0] }}");
+    var query = getWindowSearchQuery();
+    showTable(gDistro, query)
+    .then(table => gTable = table);
+
+    window.addEventListener('hashchange', (event) => {
+      // Reload the table if the distro changes
+      var url = new URL(document.location.toString());
+      console.log(`hash change url: ${url.href}`);
+      if (url.hash) {
+        gDistro = url.hash.substring(1);
+        // TODO: change cookie?
+      } else {
+        gDistro = "{{ site.distros[0] }}";
+      }
+      console.log("overriding in search_packages via anchor "+gDistro+" distro");
+      var query = getWindowSearchQuery();
+      showTable(gDistro, query)
+      .then(table => gTable = table);
+    });
+  
+    $('#search-query').on('focus', (e) => {
+      // Pre-load index to speed up search response
+      getIndex(gDistro);
+    });
+
+    $('#search-query').bind('keypress', (e) => {
+      if (e.which == 13) {
+        $("#search-enable-box").prop("checked", true);
+        copyUIToSearchQuery();
+        var query = getWindowSearchQuery() || '';
+        doSearch(gTable, gDistro, query)
+      }
+    });
+  
+    $("#search-enable-box").on('click', (e) => {
+      element = e.currentTarget;
+      console.log(`#search-enable click ${element.checked}`);
+      query = $("#search-query").val();
+      if (element.checked && query) {
+        copyUIToSearchQuery();
+        doSearch(gTable, gDistro, query);
+      } else {
+        setWindowSearchQuery('');
+        removeFilterByField(gTable, 'id');
+      }
+    });
+
+    $("#search-button").on('click', (e) => {
+      query = $("#search-query").val();
+      if (query) {
+        $("#search-enable-box").prop("checked", true);
+        copyUIToSearchQuery();
+        doSearch(gTable, gDistro, query);
+      }
+    });
+
+  });
+</script>

--- a/_ruby_libs/pages.rb
+++ b/_ruby_libs/pages.rb
@@ -88,6 +88,37 @@ class RepoPage < Jekyll::Page
   end
 end
 
+class SearchPackageListPage < Jekyll::Page
+  def initialize(site, sort_id, n_list_pages, page_index, list, default=false)
+    @site = site
+    @base = site.source
+    @dir = 'search_packages/'
+    @name = 'index.html'
+
+    self.process(@name)
+    self.read_yaml(File.join(@base, '_layouts'),'search_packages.html')
+    self.data['pager'] = {
+      'base' => 'packages',
+      'post_ns' => '/'
+    }
+    # self.data['sort_id'] = sort_id
+    #self.data['n_list_pages'] = n_list_pages
+    #self.data['page_index'] = page_index
+    #self.data['list'] = list
+    self.data['title'] = 'ROS Packages'
+
+    #self.data['prev_page'] = [page_index - 1, 1].max
+    #self.data['next_page'] = [page_index + 1, n_list_pages].min
+
+    #self.data['near_pages'] = *([1,page_index-4].max..[page_index+4, n_list_pages].min)
+    self.data['all_distros'] = site.config['distros'] + site.config['old_distros']
+
+    self.data['available_distros'] = Hash[site.config['distros'].collect { |d| [d, true] }]
+    self.data['available_older_distros'] = Hash[site.config['old_distros'].collect { |d| [d, true] }]
+    self.data['n_available_older_distros'] = site.config['old_distros'].length
+  end
+end
+
 class PackageListPage < Jekyll::Page
   def initialize(site, sort_id, n_list_pages, page_index, list, default=false)
     @site = site

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -488,3 +488,29 @@ th.rotatel90 > div > span {
   border-bottom: 2px solid #ccc;
   padding: 5px 10px;
 }
+
+/* Collapsable filter and search. */
+.collapsed .collapsing-icon::before {
+  // glyphicon-chevron-down
+  content: "\e114";
+}
+.collapsing-icon::before {
+  // glyphicon-chevron-up
+  content: "\e113";
+}
+.collapsing-header:hover {
+  text-decoration: underline;
+}
+
+/* checkbox in search_package */
+#search-enable-box {
+  border: thin solid gray;
+  border-radius: 2px;
+  width: 16px;
+  height: 16px;
+  line-height: 16px;
+  display: inline-block;
+  text-align: center;
+  vertical-align: middle;
+  margin-right: 4px;
+}

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -1,10 +1,21 @@
 /**
+ * Sizing for no-scroll table page
+ */
+:root {
+  --header-height: 60px;
+  --footer-height: 52px;
+  --content-height: calc(100vh - var(--header-height) - var(--footer-height));
+  --search-height: 60px;
+  --distro-height: 30px;
+}
+
+/**
  * Site header
  */
 .site-header {
     border-top: 5px solid $grey-color-dark;
     border-bottom: 1px solid $grey-color-light;
-    min-height: 56px;
+    height: var(--header-height);
 
     // Positioning context for the mobile navigation icon
     position: relative;
@@ -93,7 +104,8 @@
  */
 .site-footer {
     border-top: 1px solid $grey-color-light;
-    padding: $spacing-unit 0;
+    padding: $spacing-unit/2 0;
+    height:  var(--footer-height);
 }
 
 .footer-heading {

--- a/js/distro_switch.js
+++ b/js/distro_switch.js
@@ -61,4 +61,5 @@ function setupDistroSwitch(default_distro) {
   $('.distro-'+distro).show(0);
   $('#'+distro+'-option').addClass('active');
   $('#'+distro+'-button').trigger("click");
+  return distro;
 }


### PR DESCRIPTION
This is one of a series of PRs to implement a new Tabulator-based combined package search & list page, as discussed in #415. This current PR implements the new page, but does not expose it in the UI. To see the new page, you need to manually enter (website)/search_packages/ in the URL bar. This PR though can be landed independently, or in combination with, #437. After both of these are landed, a simple change to the header link will switch between the old and new package list page. (Or that could be done in this PR if desired instead).