### PR TITLE
Add OpenEmbedded to system deps, limit display of non-tiered platforms

### DIFF
--- a/_data/common.yml
+++ b/_data/common.yml
@@ -49,6 +49,9 @@ platforms:
   mandrake:
     name: 'Mandrake/Mandriva Linux'
     versions: {}
+  openembedded:
+    name: 'OpenEmbedded/Yocto Project'
+    versions: {}
   opensuse:
     name: 'openSUSE'
     versions: {}
@@ -108,3 +111,13 @@ package_manager_names:
   pacman: ['arch']
   pip: []
   portage: ['gentoo']
+
+# These are the platforms currently listed as Tier 1-3 in REP-2000 for currently supported distros.
+# It is used to limit the display of platforms when space is at a premium. Items consist of a
+# Hash with <platforms key>: '<display name>'
+current_platforms:
+  debian: 'Debian'
+  openembedded: 'OpenEmbedded'
+  osx: 'macOS'
+  rhel: 'RHEL'
+  ubuntu: 'Ubuntu'

--- a/_layouts/system_deps.html
+++ b/_layouts/system_deps.html
@@ -25,9 +25,9 @@ layout: default
               </th>
               <th style="text-align: right;">Usage</th>
               <th style="text-align: left;">Description</th>
-              {% for platform in site.data.common.platforms %}
+              {% for platform in site.data.common.current_platforms %}
                 <th style="text-align:left;" class="rotatel90">
-                  <div><span>{{platform[0]}}</span></div>
+                  <div><span>{{platform[1]}}</span></div>
                 </th>
               {% endfor %}
             </tr>
@@ -44,11 +44,9 @@ layout: default
                 </td>
                 <td style="text-align: right;">{{dep_usage}}</td>
                 <td>{{dep_description}}</td>
-                {% for p in site.data.common.platforms %}
-                  {% assign platform = p[0] %}
-                  {% assign platform_details = p[1] %}
-                  {% assign versions = platform_details.versions %}
-
+                {% for cp in site.data.common.current_platforms %}
+                  {% assign platform = cp[0] %}
+                  {% assign versions = site.data.common.platforms[platform].versions %}
 
                   {% assign found_all = true %}
                   {% assign found_one = false %}

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -472,7 +472,7 @@ a.question-link {
 
  th.rotatel90 {
   /* Something you can count on */
-  height: 70px;
+  height: 90px;
   white-space: nowrap;
 }
 
@@ -486,7 +486,7 @@ th.rotatel90 > div {
 }
 th.rotatel90 > div > span {
   border-bottom: 2px solid #ccc;
-  padding: 5px 10px;
+  padding: 2px 0px;
 }
 
 /* Collapsable filter and search. */


### PR DESCRIPTION
This PR is an intermediate step in a longer-term plan (see #415) to remove the paged listing pages for packages and dependencies, and the separate search pages, and replace them with pages that are implemented as a scrolled, searchable  lists using Tabulator. That is implemented for packages in PR #438.

I want to eliminate the old combined packages & dependencies search pages from rosindex, but I cannot do that until I implement system dependency search in Tabulator. This PR is an intermediate simplification prior to doing that.

In #415, I mention that the system dependency list is one of three core functionalities of rosindex, along with the particulars of items in the lists. This list is fairly buried in current rosindex (under INDEX/system dependencies in the header), but has a much more prominent position in my proposed format, which you can see at [devindex](https://devindex.rosdabbler.com/deps/)

The current list (which was mostly broken until recently, see #416), displays a long list of platform types with no formal tier support within ROS. This PR:

- Only displays current platforms (with a listed Tier in REP2000) on the System Dependencies list page. (This includes Debian, MacOS, OpenEmbedded [which is newly displayed], RHEL, and Ubuntu; excluded now is arch, centos, cygwin, fedora, freebsd, mandrake, opensuse). Note the excluded platforms are still visible on the system dependency detail page. Windows is not shown as their package dependency management is complex, and not currently supported in rosindex).
- The displayed name on the system dependency list page is now set separately from the platform identifier. Thus osx becomes MacOS for example. This does not affect search at the moment, but will in a future update (along with the currently not-searched, and relatively recently added, description).

The result of this can be seen (within a few hours of this PR request appearing) at https://index.rosdabbler.com/deps/ and can be seen with a few additional commits that have not currently released as PRs (such as newly-included PIP descriptions) at https://devindex.rosdabbler.com/deps/