### PR TITLE
Combined search/list deps page

### DIFF
--- a/_data/common.yml
+++ b/_data/common.yml
@@ -116,8 +116,8 @@ package_manager_names:
 # It is used to limit the display of platforms when space is at a premium. Items consist of a
 # Hash with <platforms key>: '<display name>'
 current_platforms:
-  debian: 'Debian'
-  openembedded: 'OpenEmbedded'
-  osx: 'macOS'
-  rhel: 'RHEL'
   ubuntu: 'Ubuntu'
+  rhel: 'RHEL'
+  debian: 'Debian'
+  osx: 'macOS'
+  openembedded: 'OpenEmbedded'

--- a/_layouts/noscroll-default.html
+++ b/_layouts/noscroll-default.html
@@ -42,8 +42,6 @@
     <script src={{ "/js/jquery-cookie.js" | prepend: site.baseurl }} type="text/javascript"></script>
     {% include_cached google_analytics.html %}
     <script type="text/javascript" src={{ "/js/toc.js" | prepend: site.baseurl }}></script>
-
-    <script src={{ "/js/distro_switch.js" | prepend: site.baseurl }}></script>
   </head>
 
   <body style="height: 100vh;">

--- a/_layouts/search_deps.html
+++ b/_layouts/search_deps.html
@@ -4,7 +4,7 @@ layout: noscroll-default
 <div class="container-fluid" style="padding-top:10px; height:100%;">
   <div class="container-fluid" style="height:100%;">
     <div class="row" style="height:var(--distro-height);">
-      {% include distro_switch.html %}
+      <h4 style="margin-top:2px;">System Dependencies</h4>
     </div>
     <div class="row" style="height:var(--search-height);">
       <div class="panel panel-default" style="height:100%;">
@@ -17,18 +17,28 @@ layout: noscroll-default
                   <span class="hidden-xs"> Enable search </span>
                 </span>
                 <input id="search-query" type="text" class="form-control"
-                        autocomplete="off" placeholder="Search packages">
+                        autocomplete="off" placeholder="Search dependencies">
                 <span class="input-group-btn">
-                  <button id="search-button" title="Search packages" class="btn btn-default">
+                  <button id="search-button" title="Search dependencies" class="btn btn-default">
                     <span class="glyphicon glyphicon-search"></span>
                   </button>
                 </span>
               </div>
             </div>
-            <div class="col-xs-6">
-              <p style="line-height:35px"><span class="hidden-xs">Showing </span>
+            <div class="col-xs-4">
+              <p style="line-height:35px">
+                <span class="hidden-xs">Showing </span>
                 <span id="table-filtered-count">0</span> of
-                <span id="table-unfiltered-count">0</span> packages
+                <span id="table-unfiltered-count">0</span>
+                <span class="hidden-xs"> dependencies</span>
+              </p>
+            </div>
+            <div class="col-xs-2 text-right">
+              <p style="line-height:35px">
+                <a href="{{site.baseurl}}/help/system_dependencies/">
+                  <span class="glyphicon glyphicon-question-sign"></span>
+                  <span class="hidden-xs"> Help</span>
+                </a>
               </p>
             </div>
           </div>
@@ -36,7 +46,7 @@ layout: noscroll-default
       </div>
     </div>
     <div class="row" style="height:calc(100% - var(--search-height) - var(--distro-height))">
-      <div id="packages-table"></div>
+      <div id="dependencies-table"></div>
     </div>
   </div>
 </div>
@@ -44,15 +54,14 @@ layout: noscroll-default
 <!-- See https://github.com/olifolkerd/tabulator/issues/4419 for issue with Tabulator post-5.6.0 -->
 <link href="https://cdn.jsdelivr.net/npm/tabulator-tables@6.3.0/dist/css/tabulator.min.css" rel="stylesheet">
 <!-- <script src={{ "/js/tabulator.js" | prepend: site.baseurl }}></script> -->
-<script src={{ "/js/distro_switch.js" | prepend: site.baseurl }}></script>
 <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/tabulator-tables@6.3.0/dist/js/tabulator.min.js"></script>
 <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/luxon@3.5.0/build/global/luxon.min.js"></script>
-<script src="{{site.baseurl}}/js/lunr.js" type="text/javascript" charset="utf-8"></script>
+<script src="{{ site.baseurl }}/js/lunr.js" type="text/javascript" charset="utf-8"></script>
 <script type="text/javascript">
-  var gData_promises = {};
-  var gIndex_promises = {};
+  var gData_promise = null;
+  var gIndex_promise =null;
   var gTable = null;
-  var gDistro = "{{ site.distros[0] }}";
+  const DEFAULT_SORT = [{column:"url", dir:"asc"}]
 
   function addFilter(table, field, type, value) {
     // Add a new table filter, removing existing
@@ -69,42 +78,41 @@ layout: noscroll-default
     }
   }
 
-  function getData(distro) {
-    // start and return a promise to get distro json data
-    if (distro in gData_promises) {
-      return gData_promises[distro];
+  function getData() {
+    // start and return a promise to get json data
+    if (gData_promise) {
+      return gData_promise;
     }
-    gData_promises[distro] =
-      fetch(`{{site.baseurl}}/search/packages/data.${distro}.json`)
+    gData_promise =
+      fetch(`{{ site.baseurl }}/search/deps/data.0.json`)
         .then((response) => response.json());
 
-    return gData_promises[distro];
+    return gData_promise;
   }
 
-  function getIndex(distro) {
-    console.log(`getIndex for ${distro}`);
-    // start and return a promise to get distro json index
-    if (distro in gIndex_promises) {
-      return gIndex_promises[distro];
+  function getIndex() {
+    // start and return a promise to get json index
+    if (gIndex_promise) {
+      return gIndex_promise;
     }
-    gIndex_promises[distro] =
-      fetch(`{{site.baseurl}}/search/packages/index.${distro}.json`)
+    gIndex_promise =
+      fetch(`{{ site.baseurl }}/search/deps/index.0.json`)
         .then((response) => response.json())
         .then((indexData) => {
           return lunr.Index.load(indexData);
         });
 
-    return gIndex_promises[distro];
+    return gIndex_promise;
   }
 
   function getWindowSearchQuery() {
-    return new URL(window.location.toString()).searchParams.get('pkgs');
+    return new URL(window.location.toString()).searchParams.get('deps');
   }
 
   // Populate the search input with querystring parameter
   function setWindowSearchQuery(query) {
     var url = new URL(window.location.toString());
-    url.searchParams.set('pkgs', query);
+    url.searchParams.set('deps', query);
     window.history.pushState({}, '', url);
   }
 
@@ -122,78 +130,95 @@ layout: noscroll-default
     }
   }
 
-  // Returns a promise resolving to a search array of id hits.
-  function getSearchArray(distro, query) {
+  // Returns a promise resolving to a hash of {ref: score} with hits
+  function getSearchHash(query) {
     if (!query) {
       return Promise.resolve(null);
     }
-    return getIndex(distro).then(searchIndex => {
+    return getIndex().then(searchIndex => {
       var searchResults = searchIndex.search(query);
-      searchArray = searchResults.map((result) => parseInt(result.ref));
-      console.log(`Search returned ${searchArray.length} results`);
       // Tabulator filters don't seem to work with zero entries
-      searchArray = searchArray.length ? searchArray : [-1];
-      return searchArray;
+      searchHash = {'-1': 0.0};
+      for (const result of searchResults) {
+        searchHash[result.ref] = result.score;
+      }
+      console.log(`Search returned ${searchResults.length} results`);
+      return searchHash;
     });
   }
 
-  function doSearch(table, distro, query) {
+  function doSearch(table, query) {
     console.log(`doSearch query="${query}"`);
-    getSearchArray(distro, query)
-    .then(searchArray => {
-      if (searchArray) {
-        addFilter(table, 'id', 'in', searchArray)
-      } else {
-        removeFilterByField(table, 'id');
-      }
+    getData().then(data => {
+      getSearchHash(query).then(searchHash => {
+        // Add score to table data
+        for (const dataValue of data) {
+          ref = dataValue['id'].toString();
+          if (searchHash && ref in searchHash) {
+            dataValue['score'] = searchHash[ref];
+          }
+          else {
+            dataValue['score'] = 0.0;
+          }
+        }
+        if (searchHash) {
+          keysArray = Object.keys(searchHash).map((key) => parseInt(key));
+          addFilter(table, 'id', 'in', keysArray);
+          table.setSort([
+            {column:'score', dir:'desc'}
+          ]);
+        }
+        else {
+          removeFilterByField(table, 'id');
+          table.setSort([
+            DEFAULT_SORT
+          ]);
+        }
+      })
     })
   }
 
-  function makeTable(distro, data, searchArray) {
-    const CALENDAR = "\u{1F4C5}";
-    const STAR = "\u2605";
-    const LEFT_ARROW = "\u2B05"
-    const RIGHT_ARROW = "\u27A1"
-
+  function makeTable(data, searchArray) {
+    const RIGHT_ARROW = "\u27A1";
     var initialFilter = (searchArray === undefined || searchArray === null) ?
       [] : [{field: 'id', type: 'in', value: searchArray}];
 
-    const table = new Tabulator("#packages-table", {
+    columns = [ // Define Table Columns
+      { title:"Dependency Name", field:"url", minWidth:150, maxWidth:200,
+        formatter:"link", formatterParams:{labelField:"name", urlPrefix:"{{ site.baseurl }}"}},
+      { title:"Description", field:"description", minWidth:300},
+      { title:RIGHT_ARROW, field:"usage", width:40, hozAlign:"right", headerTooltip:"dependency used by count"},
+      { title:"score", field:"score", visible:false},
+    ];
+
+    {% for cp in site.data.common.current_platforms %}
+      {% assign key = cp[0] %}
+      {% assign name = cp[1] %}
+      columns.push({ title: "{{ name }}", field: "{{ key }}", width: 90, headerTooltip:"{{ name }}", hozAlign:"center"});
+    {% endfor %}
+
+    const table = new Tabulator("#dependencies-table", {
+      columnDefaults:{ tooltip:true },
       maxHeight:"100%",
-      // height: "400px",
       data:data, //assign data to table
       layout:"fitColumns", //fit columns to width of table (optional)
       rowHeight:30, // Workaround for https://github.com/olifolkerd/tabulator/issues/4419
       initialFilter: initialFilter,
-      columns:[ //Define Table Columns
-        { title:"Name", field:"url", width:200,
-          formatter:"link", formatterParams:{labelField:"name", urlPrefix:"{{site.baseurl}}"}},
-        { title:"Description", field:"description", minWidth:300},
-        { title:STAR, field:"released", width:40, formatter:"tickCross", headerTooltip:"release status", hozAlign:"center",
-          formatterParams: {allowTruthy: true, allowEmpty: true}},
-        { title:CALENDAR, field: "last_commit_time", width:80, headerHozAlign:"center", headerTooltip:"last commit date",
-          sorter:"date", sorterParams:{format:"yyyy-MM-dd"}},
-        { title:LEFT_ARROW, field:"pkg_deps", width:40, headerTooltip:"package dependency count"},
-        { title:RIGHT_ARROW, field:"dependants", width:40, headerTooltip:"package used by count"},
-        { title:"Authors", field:"authors", width:120},
-        { title:"Maintainers", field:"maintainers", width:120},
-        { title:"Repo", field:"repo_name", width:100,
-          formatter:"link", formatterParams:{labelField:"repo_name", url:(cell) =>
-          { return `{{site.baseurl}}/r/${cell.getValue()}/#${distro}`}}},
-        { title:"Org", field:"org", width:100},
-      ],
+      initialSort: DEFAULT_SORT,
+      columns: columns,
     });
     return table;
   }
 
   // Returns a promise that resolves to a Tabulator table
-  function showTable(distro, query) {
-    console.log(`showTable distro: ${distro}, query: ${query}`);
-    var searchPromise = query ? getSearchArray(distro, query) : Promise.resolve(null);
-    return Promise.all([getData(distro), searchPromise]).then(values => {
+  function showTable(query) {
+    console.log(`showTable query: ${query}`);
+    var searchPromise = query ? getSearchHash(query) : Promise.resolve(null);
+    return Promise.all([getData(), searchPromise]).then(values => {
       var data = values[0];
-      var searchArray = values[1];
-      const table = makeTable(distro, data, searchArray);
+      var searchHash = values[1];
+      searchArray = searchHash ? Object.keys(searchHash).map(ref => parseInt(ref)) : [];
+      const table = makeTable(data, searchArray);
       $("#table-filtered-count").text(data.length);
       $("#table-unfiltered-count").text(data.length);
       table.on("dataFiltered", (filters, rows) => {
@@ -211,30 +236,19 @@ layout: noscroll-default
   $(function() {
     console.log('document ready');
     copySearchQueryToUI();
-    gDistro = setupDistroSwitch("{{ site.distros[0] }}");
     var query = getWindowSearchQuery();
-    showTable(gDistro, query)
+    showTable(query)
     .then(table => gTable = table);
 
     window.addEventListener('hashchange', (event) => {
-      // Reload the table if the distro changes
-      var url = new URL(document.location.toString());
-      console.log(`hash change url: ${url.href}`);
-      if (url.hash) {
-        gDistro = url.hash.substring(1);
-        // TODO: change cookie?
-      } else {
-        gDistro = "{{ site.distros[0] }}";
-      }
-      console.log("overriding in search_packages via anchor "+gDistro+" distro");
       var query = getWindowSearchQuery();
-      showTable(gDistro, query)
+      showTable(query)
       .then(table => gTable = table);
     });
-  
+
     $('#search-query').on('focus', (e) => {
       // Pre-load index to speed up search response
-      getIndex(gDistro);
+      getIndex();
     });
 
     $('#search-query').bind('keypress', (e) => {
@@ -242,20 +256,23 @@ layout: noscroll-default
         $("#search-enable-box").prop("checked", true);
         copyUIToSearchQuery();
         var query = getWindowSearchQuery() || '';
-        doSearch(gTable, gDistro, query)
+        doSearch(gTable, query);
       }
     });
-  
+
     $("#search-enable-box").on('click', (e) => {
       element = e.currentTarget;
       console.log(`#search-enable click ${element.checked}`);
       query = $("#search-query").val();
       if (element.checked && query) {
         copyUIToSearchQuery();
-        doSearch(gTable, gDistro, query);
+        doSearch(gTable, query);
       } else {
         setWindowSearchQuery('');
         removeFilterByField(gTable, 'id');
+        if (gTable) {
+          gTable.setSort(DEFAULT_SORT);
+        }
       }
     });
 
@@ -264,7 +281,7 @@ layout: noscroll-default
       if (query) {
         $("#search-enable-box").prop("checked", true);
         copyUIToSearchQuery();
-        doSearch(gTable, gDistro, query);
+        doSearch(gTable, query);
       }
     });
 

--- a/_plugins/rosindex_generator.rb
+++ b/_plugins/rosindex_generator.rb
@@ -32,6 +32,8 @@ require_relative '../_ruby_libs/dependency_descriptions'
 $fetched_uris = {}
 $debug = false
 DEFAULT_LANGUAGE_PREFIX = 'en'
+HEAVY_CHECKMARK = "\u2714"
+HEAVY_MINUS = "\u2796"
 
 def get_ros_api(elem)
   return []
@@ -827,6 +829,10 @@ class Indexer < Jekyll::Generator
   def generate_search_package_list(site, elements, default_sort_key)
     site.pages << SearchPackageListPage.new(site, default_sort_key, 1, 1, elements, true)
   end
+
+  def generate_search_deps_list(site)
+    site.pages << SearchDepsListPage.new(site)
+  end
  
   def generate_sorted_paginated_deps(site, elements_sorted, default_sort_key, n_elements, elements_per_page, page_class)
 
@@ -1512,7 +1518,8 @@ def generate_sorted_paginated(site, elements_sorted, default_sort_key, n_element
     generate_sorted_paginated(site, packages_sorted, 'time', @package_names.length, site.config['packages_per_page'], PackageListPage)
 
     search_packages_sorted = sort_packages(site)
-      generate_search_package_list(site, search_packages_sorted, 'time')
+    generate_search_package_list(site, search_packages_sorted, 'time')
+    generate_search_deps_list(site)
 
     # create rosdep pages
     puts ("Generating rosdep pages...").blue
@@ -1601,16 +1608,27 @@ def generate_sorted_paginated(site, elements_sorted, default_sort_key, n_element
       system_deps_index = []
       @rosdeps.each do |dep_name, full_dep_data|
         dependants_per_distro = full_dep_data['dependants_per_distro']
+        usage = 0
+        dependants_per_distro.each do |_, platform_usage|
+          usage += platform_usage.length
+        end
         data_per_platform = full_dep_data['data_per_platform']
-        system_deps_index << {
+        aliases = Set[]
+
+        system_deps_index_item = {
           'id' => system_deps_index.length,
           'url' => File.join('/d', dep_name),
           'name' => dep_name,
+          'description' => full_dep_data['description'] || '',
+          'usage' => usage,
+          'score': 0.0,
+          # The lunr tokenizr by default splits strings into tokens, using a default separator
+          # of ' ' and '-'. So we do not need to add these tags to the index for search purposes.
+          # 'tags' => dep_name.split('-') * " ",
           'platforms' => data_per_platform.collect do |platform_key, data|
             next if data.empty?
             next unless site.data['common']['platforms'].key? platform_key
             platform_details = site.data['common']['platforms'][platform_key]
-
             platform_name = platform_details['name']
             platform_versions = platform_details['versions']
             if platform_versions.size > 0
@@ -1623,15 +1641,18 @@ def generate_sorted_paginated(site, elements_sorted, default_sort_key, n_element
                   version_name = version_key.capitalize
                 end
                 names_for_version.collect do |name|
+                  aliases.add(name)
                   "#{name} (#{platform_name} #{version_name})"
                 end.join(' : ')
               end.compact.join(' : ')
             else
               data.collect do |name|
+                aliases.add(name)
                 "#{name} (#{platform_name})"
               end.join(' : ')
             end
           end.compact.join(' : '),
+          'aliases' => aliases.to_a.join(' '),
           'dependants' => dependants_per_distro.collect do |distro, dependants|
             next if dependants.empty?
             dependants.map do |dependant|
@@ -1639,12 +1660,64 @@ def generate_sorted_paginated(site, elements_sorted, default_sort_key, n_element
             end.join(' : ')
           end.compact.join(' : ')
         }
+
+        platform_availables = []
+
+        site.data['common']['current_platforms'].each do |cp, platform_name|
+          versions = site.data['common']['platforms'][cp]['versions']
+          found_all = true
+          found_one = false
+          dep_platform = data_per_platform[cp]
+          n_versions = versions.size
+          if n_versions > 0
+            versions.keys.each do |v|
+              dep_version = dep_platform[v]
+              n_deps = dep_version.size
+              if n_deps > 0
+                found_one = true
+              else
+                found_all = false
+              end
+            end
+          else
+            n_deps = dep_platform.size
+            if n_deps > 0
+              found_one = true
+            else
+              found_all = false
+            end
+          end
+
+          if found_all
+            availability = HEAVY_CHECKMARK
+          elsif found_one
+            availability = HEAVY_MINUS
+          else
+            availability = ''
+          end
+
+          if found_one or found_all
+            platform_availables << cp
+            if cp.downcase != platform_name.downcase
+              platform_availables << platform_name
+            end
+          end
+
+          system_deps_index_item[cp] = availability
+        end
+
+        # Calculate dep availability per platform. Add both platform key and name to a searchable
+        # field to allow searching, for example, for "RHEL".
+        system_deps_index_item['platforms'] = platform_availables.join(' ')
+        system_deps_index << system_deps_index_item
       end
 
       puts ("Precompiling lunr index for system dependencies...").blue
       reference_field = 'id'
-      indexed_fields = ['name', 'platforms', 'dependants']
-      slice_length = system_deps_index.length / site.config['search_index_shards'] || 1
+      # indexed_fields = ['name', 'platforms', 'dependants', 'description', 'aliases']
+      indexed_fields = ['name', 'description', 'dependants', 'aliases', 'platforms']
+      deps_shards = 1
+      slice_length = system_deps_index.length / deps_shards || 1
       slices = {}
       system_deps_index.each_slice(slice_length).with_index.map { |item, i| slices[i.to_s] = item }
       site.static_files.push(*precompile_lunr_index(

--- a/_ruby_libs/pages.rb
+++ b/_ruby_libs/pages.rb
@@ -119,6 +119,24 @@ class SearchPackageListPage < Jekyll::Page
   end
 end
 
+class SearchDepsListPage < Jekyll::Page
+  def initialize(site)
+    @site = site
+    @base = site.source
+    @dir = 'search_deps/'
+    @name = 'index.html'
+
+    self.process(@name)
+    self.read_yaml(File.join(@base, '_layouts'),'search_deps.html')
+    self.data['pager'] = {
+      'base' => 'packages',
+      'post_ns' => '/'
+    }
+    self.data['title'] = 'System Dependencies'
+  end
+end
+
+
 class PackageListPage < Jekyll::Page
   def initialize(site, sort_id, n_list_pages, page_index, list, default=false)
     @site = site

--- a/help/index.md
+++ b/help/index.md
@@ -1,0 +1,12 @@
+---
+layout: page
+title: Help for using rosindex
+permalink: /help/
+breadcrumbs: ['help']
+---
+
+# Help
+
+Current help pages:
+
+- [**System Dependencies**](/help/system_dependencies/) System Dependencies list.

--- a/help/system_dependencies/index.md
+++ b/help/system_dependencies/index.md
@@ -1,0 +1,47 @@
+---
+layout: page
+title: Help for using rosindex system dependencies list and search
+permalink: /help/system_dependencies/
+breadcrumbs: ['help', 'system_dependencies']
+---
+
+# System Dependencies Help
+
+**rosindex** provides a [**System Dependencies**](/search_deps/) page that gives a searchable list of system dependencies within ROS. This help page describes the usage of that page.
+
+ROS dependencies are identifiers that ROS uses to locate additional packages and external libraries that are needed to load a package. See [this tutorial](https://docs.ros.org/en/rolling/Tutorials/Intermediate/Rosdep.html) for a general introduction to dependencies in ROS.
+
+The identifiers of these external libraries come from the [rosdep folder in the rosdistro github site](https://github.com/ros/rosdistro/tree/master/rosdep). These identifiers provide a layer of abstraction between these external libraries and their sources in various library package managers. That way, all ROS packages are using the same names for a particular library, even though it might be called different things in various platforms that are supported by ROS. **rosindex** only shows on this page the external libraries, ROS packages are shown on another page.
+
+## Fields in System Dependencies
+
+- Dependency Name: This is the name that ROS uses to identify the library, for example as used in `<depends>` in `package.xml`. You can click on the name to take you to a detail page for that library.
+- Description: This is a description taken from the upstream library package managers for the dependency. Some of these are missing as we do not yet support getting descriptions from all upstream library package managers.
+- Dependency used-by count (➡): This is a count of the number of released packages, in all rosdistros, that depend on a particular system dependency. Many of these are zero, as these dependencies may be used by private packages that are not listed in the public rosdistro releases.
+- Various platforms (Ubuntu, RHEL, etc.): This shows the availability of the particular library in platforms currently recognized by ROS in a defined tier. Other platforms may also be supported that are not in defined tiers, see the dependency detail page for more info. Windows is not shown as its package management is in flux within ROS. A checkmark means that the dependency is supported in all known versions of a platform, while a dash means that the dependency is supported in a least one version of a platform.
+
+## Searching
+
+**rosindex** uses [lunr search](https://lunrjs.com/) to perform full-text search on information about dependencies. You may get some general help on using lunr search on the [lunr site](https://lunrjs.com/guides/searching.html), but here's a summary:
+
+In the search field, you may enter some search text, and lunr search will search all fields for that value. Items separated by spaces search for either of the values. To specify that a value must occur (logical and), prefix the term with a plus sign "+". Also, both entered searches and their corresponding search index fields treat dashes '-' like spaces, so an item like "libnl-dev" is treated like two search terms, "libnl" and "dev". All seaches are case independent.
+
+**rosindex** searches the following fields within dependencies:
+- name: "Dependency Name", the identifier used within ROS to specify a particular dependency.
+- description: The description obtained from the upstream package manager.
+- dependants: ROS package names that use a particular system dependency.
+- platforms: Which platforms (ubuntu, rhel, etc.) support a dependency.
+- aliases: These are alternate names that a dependency uses upstream. For example, dependency "cdk" is known as "libcdk5" in debian. You may search for that package either by its ROS name ("cdk") or by its debian alias ("libcdk5").
+
+When a search is performed, the results list is sorted by the quality of the search hit, though this order may be changed by clicking on headers for each column name.
+
+There is additional syntax available on the [lunr search page description](https://lunrjs.com/guides/searching.html) as well, but these details are not usually needed with **rosindex**.
+
+### Example searches
+
+- `boost`: Show the library boost, or other libraries that mention boost
+- `name:boost`: Show libraries with 'boost' in the name.
+- `rhel`: Show libraries that support rhel (Red Hat Enterprise Linux)
+- `network`: Show libraries that mention 'network' in a field (probably in the description)
+- `libasio`: Show libraries that use the name 'libasio' in their library package manager (which is used in debian)
+- `actionlib`: Show libraries that are used by the 'actionlib' ROS package


### PR DESCRIPTION
This adds a tabulator-based combined list and search page for system dependencies. Much of this is a copy of what we did with the package list page. This does not show this new page in the UI (like with package list), to view it you need to enter `/search_deps/`

It adds additional fields to deps, allow searching by upstream package name, platform, ROS package dependant, in addition to dep name and description. I'm not sure system dependency search needs all of this, but it was not difficult to add.

This removes the sharding from the search data for deps, which also affects the existing search page. The size still seems managable. It will eventually be smaller once we remove the old search pages, as there is a lot of extraneous information in the data and index that was used by the old search page, but is not needed by the new one.

Although largely copied from the new package search page, there are two new features here that I also intend to add to the package search: initial sort by search score, and an extensive help page.

Our power is out which affects my build farm, so I am unable to run a non-development build with this for demo, but I will do that as soon as the power is restored. 