### PR TITLE
Fix readme not being searched

### DIFF
--- a/_plugins/rosindex_generator.rb
+++ b/_plugins/rosindex_generator.rb
@@ -1554,7 +1554,13 @@ def generate_sorted_paginated(site, elements_sorted, default_sort_key, n_element
 
             p = package.data
 
-            readme_filtered = if p['readme'] then self.strip_stopwords(p['readme']) else "" end
+            # collect rendered readmes into simple text
+            readmes_text = ''
+            p['readmes'].each do |readme|
+              readmes_text << get_text_from_html(readme['readme_rendered'])
+            end
+
+            readme_filtered = self.strip_stopwords(readmes_text)
 
             index += 1
             packages_index[distro] << {

--- a/_ruby_libs/text_rendering.rb
+++ b/_ruby_libs/text_rendering.rb
@@ -101,3 +101,7 @@ def get_md_rst_txt(site, path, glob, raw_uri, browse_uri)
 
   return file_rendered, file_md
 end
+
+def get_text_from_html(html)
+  return Nokogiri::HTML(html).text
+end


### PR DESCRIPTION
While writing the documentation for search_packages, I noticed that package readme is not actually being searched currently by rosindex, although there is code that purports to do this. I could find no evidence that this is a recent bug, the code in question is 10 years old.

You can demo this by searching for 'slam' in humble using [the official index](https://index.ros.org/search_packages/?pkgs=slam#humble) versus [a version with this PR included](https://index.rosdabbler.com/search_packages/?pkgs=slam#humble). Without this PR, 17 packages are found. With it, 33. An example package is mrpt_map_server which mentions SLAM only in the readme, so does not appear without this PR.

A downside of this is that it makes the index.REPO.json files 2-3x larger. That means an increase in size from around 6 to around 16 megabytes for some distros. On my home setup (fiber internet 500/500 speed) the existing file downloads async in 169 milliseconds, that could presumably stretch to 500 ms with this change. This is done async as soon as the user gives focus to the search field, so under normal circumstances this is not noticed. I thought about reintroducing shrouding, but I lean against it. But it is an option (either now or later if this PR is accepted as it).