### PR TITLE
Delete non-current iron distro from home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,9 +55,6 @@ layout: default
       <a href="https://docs.ros.org/en/humble/Releases/Release-Humble-Hawksbill.html">ROS 2 Humble</a>
     </p>
     <p>
-      <a href="https://docs.ros.org/en/iron/Releases/Release-Iron-Irwini.html">ROS 2 Iron</a>
-    </p>
-    <p>
       <a href="https://docs.ros.org/en/jazzy/Releases/Release-Jazzy-Jalisco.html">ROS 2 Jazzy</a>
     </p>
     <h2>Development Distribution</h2>


### PR DESCRIPTION
Iron is eol, delete reference from home page.