### PR TITLE
Add a newline between data json objects to prevent flagging as unchanged.

### DIFF
--- a/_ruby_libs/lunr.rb
+++ b/_ruby_libs/lunr.rb
@@ -24,7 +24,7 @@ def precompile_lunr_index(site, index, ref, fields, output_dir, shard_names)
       data_filename = "data.#{name}.json"
       data_filepath = File.join(output_dirpath, data_filename)
       File.open(data_filepath, 'w') do |data_file|
-        data_file.write(JSON.generate(index[name]))
+        data_file.write(JSON.generate(index[name], options={object_nl: "\n"}))
       end
       enum.yield SearchIndexFile.new(site, site.dest, output_dir, data_filename)
       dputs("Index data written to #{data_filename}.")


### PR DESCRIPTION
I believe this fixes #463 but I have not had time to test that (which is quite tricky). But here is an explanation.

In the current code, all of the data and index .json lines are written as a single line. So if anything changes, git diff always reports this as just one line changed.

In git_add_files, changes are excluded from update if they only change a single line, and if the diff contains "generated on".

In humble, the README for package proto2ros contains the text "a ROS 2 message is generated for each one-of". Frequent word deletion removes "for each" so this becomes "generated one-of" which contains "generated on". Thus data.humble.json is blacklisted from update. So this problem is a side effect of including the README text from #452.

The proposed patch adds new-lines to each new object, so that data json files with changes will not be detected as single line changes (or so I believe). There is a small additional size added to the data json files with this.

It may take a day or two for me to test this as much as I can, but it is a pretty small change so might be worth landing as it.

