### PR TITLE
Redirect old /packages link to the new version

### DIFF
--- a/packages/index.html
+++ b/packages/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<!-- The url for the package list was changed with the introduction of a combined package search and list.
+    This file redirects to the current page.
+-->
+<html>
+  <head>
+    <meta http-equiv="refresh" content="0; URL='/?search_packages=true'" />
+  </head>
+</html>


### PR DESCRIPTION
Fixes #480.  We probably will also use this to resolve #479 without trying to insert the rosdistro value.