### PR TITLE
Add tags to the repo headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ _cache
 _remotes
 _plugins_data
 _artifacts
+rubygems

--- a/_config.yml
+++ b/_config.yml
@@ -65,6 +65,7 @@ exclude:
   - README.md
   - Makefile
   - docker
+  - rubygems
 
 index_old_doc_paths: false
 

--- a/_includes/repo_info.html
+++ b/_includes/repo_info.html
@@ -11,6 +11,10 @@
       <td>
         <h3><a style="text-decoration:none;" href="{{site.baseurl }}/r/{{page.repo.name}}">{{page.repo.name}}</a> <small>repository</small></h3>
         {% for tag in page.repo.tags %}<span class="label label-default">{{ tag }}</span> {% endfor %}
+        {% for p in page.repo.snapshots[distro].packages %}
+        <a class="label label-primary pkg-label" href="{{site.baseurl}}/p/{{p[1].name}}">{{ p[1].name }}</a>
+        {% endfor %}
+
       </td>
     </tr>
   </table>

--- a/_layouts/repo_instance.html
+++ b/_layouts/repo_instance.html
@@ -18,15 +18,16 @@ layout: default
     <div class="row">
       &nbsp;
     </div>
-    <div class="row">
-      {% include repo_info.html %}
-    </div>
+
   </div>
 </div>
 
 {% for distro in page.all_distros %}
   <div class="distro distro-{{distro}}">
     <div class="container-fluid">
+      <div class="row">
+        {% include repo_info.html %}
+      </div>
       {% if page.available_distros[distro] or page.available_older_distros[distro] %}
         {% assign repo = page.repo %}
         <div class="panel panel-default">

--- a/_layouts/repo_instance.html
+++ b/_layouts/repo_instance.html
@@ -18,7 +18,6 @@ layout: default
     <div class="row">
       &nbsp;
     </div>
-
   </div>
 </div>
 

--- a/_layouts/repo_instance.html
+++ b/_layouts/repo_instance.html
@@ -25,9 +25,7 @@ layout: default
 {% for distro in page.all_distros %}
   <div class="distro distro-{{distro}}">
     <div class="container-fluid">
-      <div class="row">
-        {% include repo_info.html %}
-      </div>
+      {% include repo_info.html %}
       {% if page.available_distros[distro] or page.available_older_distros[distro] %}
         {% assign repo = page.repo %}
         <div class="panel panel-default">


### PR DESCRIPTION
See the new tags: 

![image](https://github.com/user-attachments/assets/c0ca0acd-8877-4509-8c40-027cb4e253ce)


It needed a small tweak to show the packages per distro. 

Also ignore rubygems that get built in tree with our standard environment. 