### PR TITLE
Use Tabulator for repo list and search

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -16,7 +16,7 @@
               <a href="{{site.baseurl}}/?search_packages=true" class="btn btn-default" role="button">Package List</a>
             </div>
             <div class="btn-group" role="group">
-              <a href="{{site.baseurl}}/repos" class="btn btn-default" role="button">Repository List</a>
+              <a href="{{site.baseurl}}/?search_repos=true" class="btn btn-default" role="button">Repository List</a>
             </div>
             <div class="btn-group" role="group">
               <a href="{{site.baseurl}}/search_deps" class="btn btn-default" role="button">System Dependencies</a>
@@ -28,7 +28,7 @@
             </button>
             <ul class="dropdown-menu" aria-labelledby="hLabel">
               <li><a href="{{site.baseurl}}/?search_packages=true">Package List</a></li>
-              <li><a href="{{site.baseurl}}/repos">Repository List</a></li>
+              <li><a href="{{site.baseurl}}/?search_repos=true">Repository List</a></li>
               <li><a href="{{site.baseurl}}/search_deps">System Dependencies</a></li>
             </ul>
           </div>

--- a/_layouts/search_packages.html
+++ b/_layouts/search_packages.html
@@ -9,7 +9,7 @@ layout: default
       </ol>
       <ol class="breadcrumb showAsSearch" style="display:none">
         <li><a href="{{site.baseurl}}/">Home</a></li>
-        <li class="active">Package List</li>
+        <li id="breadcrumb-name" class="active">Package List</li>
       </ol>
     </div>
     <div class="row" style="height:var(--distro-height);">
@@ -103,6 +103,8 @@ layout: default
 
 <!-- See https://github.com/olifolkerd/tabulator/issues/4419 for issue with Tabulator post-5.6.0 -->
 <link href="https://cdn.jsdelivr.net/npm/tabulator-tables@6.3.0/dist/css/tabulator.min.css" rel="stylesheet">
+<link href={{ "css/search_packages.css" | prepend: site.baseurl }} rel="stylesheet">
+
 <!-- <script src={{ "/js/tabulator.js" | prepend: site.baseurl }}></script> -->
 <script src={{ "/js/distro_switch.js" | prepend: site.baseurl }}></script>
 <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/tabulator-tables@6.3.0/dist/js/tabulator.min.js"></script>
@@ -114,7 +116,8 @@ layout: default
   var gTable = null;
   var gDistro = "{{ site.distros[0] }}";
   var gQuery = null;
-  const DEFAULT_SORT = [{column:"url", dir:"asc"}];
+  const PACKAGE_SORT = [{column:"url", dir:"asc"}];
+  const REPO_SORT = [{column: "repo", dir:"asc"}];
   const SCORE_SORT = [{column:"score", dir:"desc"}];
 
   function setHome() {
@@ -169,7 +172,12 @@ layout: default
   }
 
   function getIsSearch() {
-    return new URL(window.location.toString()).searchParams.has('search_packages');
+    parms = new URL(window.location.toString()).searchParams;
+    return (parms.has('search_packages') || parms.has('search_repos'));
+  }
+
+  function getIsRepos() {
+    return new URL(window.location.toString()).searchParams.has('search_repos');
   }
 
   function setWindowSearchQuery(query) {
@@ -230,15 +238,46 @@ layout: default
     const STAR = "\u2605";
     const LEFT_ARROW = "\u2B05";
     const RIGHT_ARROW = "\u27A1";
+    const isRepos = getIsRepos();
 
-    const tableSort = searchArray ? SCORE_SORT : DEFAULT_SORT;
+    const tableSort = searchArray ? SCORE_SORT : (isRepos ? REPO_SORT : PACKAGE_SORT);
     if (searchArray) {
       var tableFilter = [{field: 'id', type: 'in', value: searchArray}];
     } else {
       var tableFilter = [];
     }
 
-    const table = new Tabulator("#packages-table", {
+    dateColumn =
+      { title:CALENDAR, field: "last_commit_time", width:80, headerHozAlign:"center",
+        headerTooltip:"last commit date", sorter:"date", sorterParams:{format:"yyyy-MM-dd"}
+      };
+    repoColumn =
+      { title:"Repo", field:"repo", width:100,
+        formatter:"link", formatterParams:{labelField:"repo", url:(cell) => {
+          return `{{site.baseurl}}/r/${cell.getValue()}/#${distro}`}}
+      };
+
+    tableColumns = [ //Define Table Columns
+      { title:"Package", field:"url", width:200,
+        formatter:"link", formatterParams:{labelField:"package", urlPrefix:"{{site.baseurl}}"}},
+      { title:"Description", field:"description", minWidth:isRepos ? 160: 300},
+      { title:STAR, field:"released", width:40, formatter:"tickCross", headerTooltip:"release status", hozAlign:"center",
+        formatterParams: {allowTruthy: true, allowEmpty: true}},
+      { title:LEFT_ARROW, field:"pkg_deps", width:40, headerTooltip:"package dependency count"},
+      { title:RIGHT_ARROW, field:"dependants", width:40, headerTooltip:"package used by count"},
+      { title:"Authors", field:"authors", width:120},
+      { title:"Maintainers", field:"maintainers", width:120},
+      { title:"Org", field:"org", width:100},
+      { title:"score", field:"score", width:60, sorter:"number", visible:false},
+    ];
+
+    if (isRepos) {
+      tableColumns = [dateColumn, repoColumn].concat(tableColumns);
+    } else {
+      tableColumns = tableColumns.concat([repoColumn, dateColumn]);
+    }
+
+    tableOptions = {
       columnDefaults:{ tooltip:true },
       maxHeight:"100%",
       data:data, //assign data to table
@@ -246,27 +285,24 @@ layout: default
       rowHeight:30, // Workaround for https://github.com/olifolkerd/tabulator/issues/4419
       initialSort: tableSort,
       initialFilter: tableFilter,
-      columns:[ //Define Table Columns
-        { title:"Name", field:"url", width:200,
-          formatter:"link", formatterParams:{labelField:"name", urlPrefix:"{{site.baseurl}}"}},
-        { title:"Description", field:"description", minWidth:300},
-        { title:STAR, field:"released", width:40, formatter:"tickCross", headerTooltip:"release status", hozAlign:"center",
-          formatterParams: {allowTruthy: true, allowEmpty: true}},
-        { title:CALENDAR, field: "last_commit_time", width:80, headerHozAlign:"center", headerTooltip:"last commit date",
-          sorter:"date", sorterParams:{format:"yyyy-MM-dd"}},
-        { title:LEFT_ARROW, field:"pkg_deps", width:40, headerTooltip:"package dependency count"},
-        { title:RIGHT_ARROW, field:"dependants", width:40, headerTooltip:"package used by count"},
-        { title:"Authors", field:"authors", width:120},
-        { title:"Maintainers", field:"maintainers", width:120},
-        { title:"Repo", field:"repo_name", width:100,
-          formatter:"link", formatterParams:{labelField:"repo_name", url:(cell) => {
-            return `{{site.baseurl}}/r/${cell.getValue()}/#${distro}`}}},
-        { title:"Org", field:"org", width:100},
-        { title:"score", field:"score", width:60, sorter:"number", visible:false},
-      ],
-      });
-      return table;
+      columns:tableColumns,
+    };
+
+    if (isRepos) {
+      tableOptions['groupBy'] = 'repo';
+      tableOptions['groupStartOpen'] = true;
+      tableOptions['groupToggleElement'] = false;  // Always show packages.
+      tableOptions['groupHeader'] = (value, count, data, group) => {
+        p_str = count != 1 ? 'packages' : 'package';
+        console.log(data[0]);
+        header = 
+          `<span style='color:#d00;'>${data[0]['last_commit_time']}</span>` +
+          `<span style='margin-left:11px;'><a href="/r/${value}/#${distro}">${value}</span>`;
+        return header;
+      }
     }
+    return new Tabulator("#packages-table", tableOptions);
+  }
 
   function makeBuiltTable(distro, data, searchArray) {
     // Returns a promise resolving to a built Tabulator table.
@@ -289,7 +325,17 @@ layout: default
     // Returns a promise that displays a Tabulator table.
     console.log(`showTable distro=${distro} query=${query}`);
     gQuery = query;
+    if (distro != gDistro) {
+      // Some of the table links depend on distro. Let's just rebuild the whole thing.
+      gTable = null;
+    }
     gDistro = distro;
+    var title = 'Search packages';
+    var breadcrumb = getIsRepos() ? 'Repo list' : 'Package List';
+    $('#search-button').attr('title', title);
+    $('#search-query').attr('placeholder', title);
+    $('#breadcrumb-name').text(breadcrumb);
+
     var searchPromise = getSearchHash(distro, query);
     return Promise.all([getData(distro), searchPromise]).then(values => {
       var data = values[0];
@@ -308,7 +354,7 @@ layout: default
           gTable.setSort(SCORE_SORT);
         } else {
           gTable.clearFilter(true);
-          gTable.setSort(DEFAULT_SORT);
+          gTable.setSort(getIsRepos() ? REPO_SORT : PACKAGE_SORT);
         }
         gTable.replaceData(data).then(console.log('table data replaced'));
       }
@@ -392,7 +438,7 @@ layout: default
         setWindowSearchQuery('');
         query = '';
         if (gTable) {
-          gTable.setSort(DEFAULT_SORT);
+          gTable.setSort(getIsRepos() ? REPO_SORT : PACKAGE_SORT);
         }
       }
       showTable(gDistro, query).then(setSearch());
@@ -407,7 +453,7 @@ layout: default
         setWindowSearchQuery('');
         query = '';
         if (gTable) {
-          gTable.setSort(DEFAULT_SORT);
+          gTable.setSort(getIsRepos() ? REPO_SORT : PACKAGE_SORT);
         }
       }
       showTable(gDistro, query).then(setSearch());

--- a/_layouts/search_packages.html
+++ b/_layouts/search_packages.html
@@ -24,7 +24,7 @@ layout: default
                 <input id="search-query" type="text" class="form-control"
                         autocomplete="off" placeholder="Search packages">
                 <span class="input-group-btn">
-                  <button id="search-button" title="Search packages" class="btn btn-default">
+                  <button id="search-button" class="btn btn-default">
                     <span class="glyphicon glyphicon-search"></span>
                   </button>
                 </span>
@@ -39,7 +39,7 @@ layout: default
                 <span class="hidden-xs">Showing </span>
                 <span id="table-filtered-count">0</span> of
                 <span id="table-unfiltered-count">0</span>
-                <span class="hidden-xs"> packages</span>
+                <span id="filtered-type" class="hidden-xs"> packages</span>
               </p>
             </div>
             <div class="col-xs-2 text-right" style="line-height:35px">
@@ -116,6 +116,7 @@ layout: default
   var gTable = null;
   var gDistro = "{{ site.distros[0] }}";
   var gQuery = null;
+  var gRepoCount = null;
   const PACKAGE_SORT = [{column:"url", dir:"asc"}];
   const REPO_SORT = [{column: "repo", dir:"asc"}];
   const SCORE_SORT = [{column:"score", dir:"desc"}];
@@ -221,15 +222,21 @@ layout: default
 
   function updateDataScore(data, searchHash) {
     // Update table data score with results from a search.
+    // Returns array of repo names that the search hit.
+    var reposSet = new Set();
+    // Tabulator filters don't like empty arrays.
+    reposSet.add('__dummy__');
     for (const dataValue of data) {
       const ref = dataValue['id'].toString();
       if (searchHash && ref in searchHash) {
+        reposSet.add(dataValue['repo']);
         dataValue['score'] = searchHash[ref];
       }
       else {
         dataValue['score'] = 0.0;
       }
     }
+    return Array.from(reposSet);
   }
 
   function makeTable(distro, data, searchArray) {
@@ -242,7 +249,11 @@ layout: default
 
     const tableSort = searchArray ? SCORE_SORT : (isRepos ? REPO_SORT : PACKAGE_SORT);
     if (searchArray) {
-      var tableFilter = [{field: 'id', type: 'in', value: searchArray}];
+      if (isRepos) {
+        var tableFilter = [{field: 'repo', type: 'in', value: searchArray}];
+      } else {
+        var tableFilter = [{field: 'id', type: 'in', value: searchArray}];
+      }
     } else {
       var tableFilter = [];
     }
@@ -272,8 +283,10 @@ layout: default
     ];
 
     if (isRepos) {
+      $("#filtered-type").text(' repos');
       tableColumns = [dateColumn, repoColumn].concat(tableColumns);
     } else {
+      $("#filtered-type").text(' packages');
       tableColumns = tableColumns.concat([repoColumn, dateColumn]);
     }
 
@@ -293,8 +306,6 @@ layout: default
       tableOptions['groupStartOpen'] = true;
       tableOptions['groupToggleElement'] = false;  // Always show packages.
       tableOptions['groupHeader'] = (value, count, data, group) => {
-        p_str = count != 1 ? 'packages' : 'package';
-        console.log(data[0]);
         header = 
           `<span style='color:#d00;'>${data[0]['last_commit_time']}</span>` +
           `<span style='margin-left:11px;'><a href="/r/${value}/#${distro}">${value}</span>`;
@@ -307,11 +318,31 @@ layout: default
   function makeBuiltTable(distro, data, searchArray) {
     // Returns a promise resolving to a built Tabulator table.
     var table = makeTable(distro, data, searchArray);
+    if (!gRepoCount) {
+      const reposSet = new Set();
+      for (const dataItem of data) {
+        reposSet.add(dataItem['repo']);
+      }
+      gRepoCount = reposSet.size;
+      console.log(`gRepoCount is ${gRepoCount}`)
+    }
     var tablePromise = new Promise((resolve, reject) => {
       table.on("dataFiltered", (filters, rows) => {
-        console.log(`Table filtered: total: ${table.getDataCount()} rowCount: ${rows.length}`);
-        $("#table-filtered-count").text(rows.length);
-        $("#table-unfiltered-count").text(table.getDataCount());
+        if (getIsRepos()) {
+          const rowsData = rows.map(row => row.getData());
+          var totalLength = gRepoCount;
+          const reposSet = new Set();
+          for (const row of rowsData) {
+            reposSet.add(row['repo']);
+          }
+          var hitsLength = reposSet.size;
+        } else {
+          var totalLength = table.getDataCount();
+          var hitsLength = rows.length;
+        }
+        console.log(`Table filtered: total: ${totalLength} rowCount: ${hitsLength}`);
+        $("#table-filtered-count").text(hitsLength);
+        $("#table-unfiltered-count").text(totalLength);
       });
       table.on("tableBuilt", () => {
         console.log('tableBuilt');
@@ -325,14 +356,18 @@ layout: default
     // Returns a promise that displays a Tabulator table.
     console.log(`showTable distro=${distro} query=${query}`);
     gQuery = query;
+    const isRepos = getIsRepos();
     if (distro != gDistro) {
       // Some of the table links depend on distro. Let's just rebuild the whole thing.
+      if (gTable) {
+        gTable.destroy();
+      }
       gTable = null;
+      gRepoCount = null;
     }
     gDistro = distro;
-    var title = 'Search packages';
-    var breadcrumb = getIsRepos() ? 'Repo list' : 'Package List';
-    $('#search-button').attr('title', title);
+    var title = isRepos ? 'Search repos' : 'Search packages';
+    var breadcrumb = isRepos ? 'Repo list' : 'Package List';
     $('#search-query').attr('placeholder', title);
     $('#breadcrumb-name').text(breadcrumb);
 
@@ -340,21 +375,30 @@ layout: default
     return Promise.all([getData(distro), searchPromise]).then(values => {
       var data = values[0];
       var searchHash = values[1];
-      var searchArray = searchHash ? Object.keys(searchHash).map(ref => parseInt(ref)) : null;
-      updateDataScore(data, searchHash);
+      var reposArray = updateDataScore(data, searchHash);
+      if (isRepos) {
+        var searchArray = searchHash ? reposArray : null;
+      } else {
+        var searchArray = searchHash ? Object.keys(searchHash).map(ref => parseInt(ref)) : null;
+      }
+      var filteredLength = isRepos ? reposArray.length : data.length;
       if (!searchArray) {
-        console.log(`showTable sets count to ${data.length}`);
-        $("#table-filtered-count").text(data.length);
-        $("#table-unfiltered-count").text(data.length);
+        console.log(`showTable sets count to ${filteredLength}`);
+        $("#table-filtered-count").text(filteredLength);
+        $("#table-unfiltered-count").text(filteredLength);
       }
 
       if (gTable) {
         if (searchArray) {
-          gTable.setFilter('id', 'in', searchArray);
+          if (isRepos) {
+            gTable.setFilter('repo', 'in', searchArray);
+          } else {
+            gTable.setFilter('id', 'in', searchArray);
+          }
           gTable.setSort(SCORE_SORT);
         } else {
           gTable.clearFilter(true);
-          gTable.setSort(getIsRepos() ? REPO_SORT : PACKAGE_SORT);
+          gTable.setSort(isRepos ? REPO_SORT : PACKAGE_SORT);
         }
         gTable.replaceData(data).then(console.log('table data replaced'));
       }

--- a/_plugins/rosindex_generator.rb
+++ b/_plugins/rosindex_generator.rb
@@ -1529,8 +1529,8 @@ def generate_sorted_paginated(site, elements_sorted, default_sort_key, n_element
               'url' => File.join('/p',package_name)+"#"+distro,
               'last_commit_time' => repo_snapshot.data['last_commit_time'],
               'tags' => (p['tags'] + package_name.split('_')) * " ",
-              'name' => package_name,
-              'repo_name' => repo.name,
+              'package' => package_name,
+              'repo' => repo.name,
               'released' => if repo_snapshot.released then 'released' else '' end,
               'version' => p['version'],
               'description' => p['description'].strip,
@@ -1552,7 +1552,7 @@ def generate_sorted_paginated(site, elements_sorted, default_sort_key, n_element
       puts ("Precompiling lunr index for packages...").blue
       reference_field = 'id'
       indexed_fields = [
-        'tags:100', 'name:100', 'description:50', 'maintainers', 'authors',
+        'tags:100', 'package:100', 'description:50', 'maintainers', 'authors',
         'readme', 'released', 'org', 'repo'
       ]
       site.static_files.push(*precompile_lunr_index(

--- a/css/search_packages.css
+++ b/css/search_packages.css
@@ -1,0 +1,13 @@
+/**
+ * Don't show Tabulator group open arrows
+ */
+ .tabulator-group-toggle {
+    display: none !important;
+}
+.tabulator-row.tabulator-group {
+    padding: 4px 5px 5px 4px !important;
+    margin-left: 0px !important;
+}
+.tabulator-row.tabulator-group span {
+    margin-left: 0px;
+}

--- a/help/package_list.md
+++ b/help/package_list.md
@@ -11,7 +11,7 @@ breadcrumbs: ['help']
 
 ## Fields in Package List
 
-- Name: Package name.
+- Package: Package name.
 - Description: Package description.
 - Release status (★): Release status of the package. A checkmark signifies the package is released.
 - Last commit date (📅): The last date a commit was made to the package's repository.
@@ -31,7 +31,7 @@ In the search field, you may enter some search text, and lunr search will search
 The package name is split by underscore (_), and those individual terms are added as "tags" that are included in the search. So searching for "msgs" will find packages whose name includes "_msgs", such as "control_msgs".
 
 **rosindex** searches the following fields within packages. These fields are also displayed, see above for their description:
-- name
+- package
 - description
 - maintainers
 - authors
@@ -46,7 +46,7 @@ These fields are additionally searched:
 ### Example searches
 
 - `ament_package`: packages containing 'ament_package' in any field (shows package ament_package and one other)
-- `name:ament_package` packages with the name 'ament_package' (shows only the package ament_package)
+- `package:ament_package` packages with the name 'ament_package' (shows only the package ament_package)
 - `authors:josh maintainers:josh` packages with 'Josh' as either an author, or a maintainer.
 - `org:ros2`: packages in the organization ros2
 - `msgs`: packages containing 'msgs' in any field. Since packages names are split by '_' into tags, any package with a name like *_msgs will have 'msgs' as a tag, and thus show in this search result.


### PR DESCRIPTION
Resolves #478 

This is a demo of a combined repo and package search/list page. I'll set it as a DRAFT since I'd like to look it over before we move forward. This is intended s a concrete discussion starter for an option for #478.

This has all of the information in the current repo list (and more, also is searchable) except for the list of repo variants. That could be added pretty easily if desired, though horizontal space is a bit of an issue.

The repo header is vertically aligned with the package list headers, so you can click on that header and sort by date or by repo name.

The date is included before the repo name because the repo name field is of variable length, and it is better to have the variable length field be last.

The default sort here is by repo name, unlike the original which sorts by date. It would be easy to sort by date by default if desired.

Personally I like this, for the following reasons:
- It has the same fields and general format of the package list, so if you learn how to search in one, it is obvious how to search the other. The package expansion also shows the relevant package fields.
- Using common code is easier and more maintainable than trying to do a separate js implementation of the repos. Already many lessons I have learned from doing the package list have not been transferred to the system dependencies list.

Example of repo list:

![image](https://github.com/user-attachments/assets/95178313-0157-4dde-a37c-ad2856ec53c1)
