### PR TITLE
Stop destroying table with change of distro

### DIFF
--- a/_layouts/search_packages.html
+++ b/_layouts/search_packages.html
@@ -265,7 +265,7 @@ layout: default
     repoColumn =
       { title:"Repo", field:"repo", width:100,
         formatter:"link", formatterParams:{labelField:"repo", url:(cell) => {
-          return `{{site.baseurl}}/r/${cell.getValue()}/#${distro}`}}
+          return `{{site.baseurl}}/r/${cell.getValue()}/#${gDistro}`}}
       };
 
     tableColumns = [ //Define Table Columns
@@ -308,7 +308,7 @@ layout: default
       tableOptions['groupHeader'] = (value, count, data, group) => {
         header = 
           `<span style='color:#d00;'>${data[0]['last_commit_time']}</span>` +
-          `<span style='margin-left:11px;'><a href="/r/${value}/#${distro}">${value}</span>`;
+          `<span style='margin-left:11px;'><a href="/r/${value}/#${gDistro}">${value}</span>`;
         return header;
       }
     }
@@ -358,11 +358,6 @@ layout: default
     gQuery = query;
     const isRepos = getIsRepos();
     if (distro != gDistro) {
-      // Some of the table links depend on distro. Let's just rebuild the whole thing.
-      if (gTable) {
-        gTable.destroy();
-      }
-      gTable = null;
       gRepoCount = null;
     }
     gDistro = distro;
@@ -389,6 +384,7 @@ layout: default
       }
 
       if (gTable) {
+        gTable.blockRedraw();
         if (searchArray) {
           if (isRepos) {
             gTable.setFilter('repo', 'in', searchArray);
@@ -400,7 +396,10 @@ layout: default
           gTable.clearFilter(true);
           gTable.setSort(isRepos ? REPO_SORT : PACKAGE_SORT);
         }
-        gTable.replaceData(data).then(console.log('table data replaced'));
+        gTable.replaceData(data).then(() => {
+          console.log('table data replaced')
+          gTable.restoreRedraw();
+        });
       }
       else {
         makeBuiltTable(distro, data, searchArray).then(table => {


### PR DESCRIPTION
I didn't like the way that the table flashes away briefly when changing distros. This solves that.

There was an issue that destroying and rebuilding the table solved, and that was to fix the distro fragment reference on the repo column (and group header). But I found another way to solve that, using the global gDistro. You can check that the links in the repo column point to the correct distro.

I also found the Tabulator blockRedraw function, which is used here to stop multiple table redraws when we are changing multiple things.

I have not been able to duplicate the previous issue I had seen with an occasional blank table after a search. Maybe it's gone? In any case, if it is rare, I think that getting rid of the table flash on distro change is worth the occasional glitch, if it still occurs.