### PR TITLE
Add a package column of whether a package is a "base" package.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -40,6 +40,8 @@ checkout_path: _plugins_data/checkout
 repo_name_whitelist: []
 # if non-empty, only scrape these repo ids (useful for debugging / partial db updates)
 repo_id_whitelist: []
+# always scrape these packages (useful for debugging)
+repo_name_always: []
 
 # domains which are broken
 domain_blacklist:

--- a/_config.yml
+++ b/_config.yml
@@ -40,8 +40,8 @@ checkout_path: _plugins_data/checkout
 repo_name_whitelist: []
 # if non-empty, only scrape these repo ids (useful for debugging / partial db updates)
 repo_id_whitelist: []
-# always scrape these packages (useful for debugging)
-repo_name_always: []
+# always scrape the repo containing ros_base (needed for search fields)
+repo_name_always: ['variants', 'metapackages']
 
 # domains which are broken
 domain_blacklist:
@@ -106,7 +106,7 @@ old_ros_distros:
 packages_per_page: 200
 repos_per_page: 200
 
-# uncomment the following line for testing (limit the number of indexed repos)
+# set the following to a non-zero value for testing (limit the number of indexed repos)
 max_repos: 00
 
 plugins:

--- a/_config_devel.yml
+++ b/_config_devel.yml
@@ -2,6 +2,9 @@
 packages_per_page: 5
 repos_per_page: 5
 
+# always scrape the repo containing desktop_full, (needed for search fields)
+repo_name_always: ['variants', 'metapackages']
+
 # set the following to a non-zero value for testing (limit the number of indexed repos)
 max_repos: 10
 

--- a/_config_devel.yml
+++ b/_config_devel.yml
@@ -2,9 +2,6 @@
 packages_per_page: 5
 repos_per_page: 5
 
-# always scrape the repo containing desktop_full, (needed for search fields)
-repo_name_always: ['variants', 'metapackages']
-
 # set the following to a non-zero value for testing (limit the number of indexed repos)
 max_repos: 10
 

--- a/_layouts/search_packages.html
+++ b/_layouts/search_packages.html
@@ -245,6 +245,7 @@ layout: default
     const STAR = "\u2605";
     const LEFT_ARROW = "\u2B05";
     const RIGHT_ARROW = "\u27A1";
+    const CIRCLED_DOT = "\u2299";
     const isRepos = getIsRepos();
 
     const tableSort = searchArray ? SCORE_SORT : (isRepos ? REPO_SORT : PACKAGE_SORT);
@@ -272,10 +273,14 @@ layout: default
       { title:"Package", field:"url", width:200,
         formatter:"link", formatterParams:{labelField:"package", urlPrefix:"{{site.baseurl}}"}},
       { title:"Description", field:"description", minWidth:isRepos ? 160: 300},
-      { title:STAR, field:"released", width:40, formatter:"tickCross", headerTooltip:"release status", hozAlign:"center",
+      { title:STAR, field:"released", width:40, formatter:"tickCross", headerTooltip:"released: release status", hozAlign:"center",
         formatterParams: {allowTruthy: true, allowEmpty: true}},
-      { title:LEFT_ARROW, field:"pkg_deps", width:40, headerTooltip:"package dependency count"},
-      { title:RIGHT_ARROW, field:"dependants", width:40, headerTooltip:"package used by count"},
+      { title:LEFT_ARROW, field:"pkg_deps", width:40, headerTooltip:"pkg_deps: package dependency count"},
+      { title:RIGHT_ARROW, field:"dependants", width:40, headerTooltip:"dependants: package used by count"},
+      { title:CIRCLED_DOT, field:"core", width:40, formatter:"tickCross", headerTooltip:"core: Is dependency of a core package?",
+        hozAlign:"center", formatterParams: {allowTruthy: true}, sorter:function(a, b, aRow, bRow, column, dir, sorterParams) {
+          return sorterParams.indexOf(a) - sorterParams.indexOf(b);
+        }, sorterParams:['ros_core', 'ros_base', 'desktop', 'desktop_full']},
       { title:"Authors", field:"authors", width:120},
       { title:"Maintainers", field:"maintainers", width:120},
       { title:"Org", field:"org", width:100},

--- a/_plugins/rosindex_generator.rb
+++ b/_plugins/rosindex_generator.rb
@@ -1074,7 +1074,8 @@ def generate_sorted_paginated(site, elements_sorted, default_sort_key, n_element
 
               begin
                 # limit repos if requested
-                if not @repo_names.has_key?(repo_name) and site.config['max_repos'] > 0 and @repo_names.length > site.config['max_repos'] then next end
+                if not site.config['repo_name_always'].include?(repo_name) and \
+                  not @repo_names.has_key?(repo_name) and site.config['max_repos'] > 0 and @repo_names.length > site.config['max_repos'] then next end
 
                 dputs " - "+repo_name
 

--- a/_plugins/rosindex_generator.rb
+++ b/_plugins/rosindex_generator.rb
@@ -124,6 +124,25 @@ def resolve_dep(ps, ms, os, ver, data)
   return []
 end
 
+def expand_package_deps(package_name, package_names, deps, distro)
+  # Expand package dependencies at all levels for package_name.
+  if deps.include?(package_name)
+    return
+  end
+  deps.add(package_name)
+  if not package_names.key?(package_name)
+    return
+  end
+  if not package_names[package_name].snapshots.key?(distro)
+    return
+  end
+  package_snapshot = package_names[package_name].snapshots[distro]
+  if package_snapshot
+    package_snapshot.data['pkg_deps'].keys.each do |dep_name|
+      expand_package_deps(dep_name, package_names, deps, distro)
+    end
+  end
+end
 
 class Indexer < Jekyll::Generator
   def initialize(config = {})
@@ -1494,9 +1513,21 @@ def generate_sorted_paginated(site, elements_sorted, default_sort_key, n_element
     # populate the home page with available distros
     site.pages << HomePage.new(site)
 
+    core_deps = {}
     # create lunr index data
     unless site.config['skip_search_index']
       puts ("Generating packages search index...").blue
+
+      # Determine which packages are dependencies of core packages.
+      core_packages = ['ros_core', 'ros_base', 'desktop', 'desktop_full']
+      $all_distros.each do |distro|
+        core_deps[distro] = {}
+        core_packages.each do |parent_name|
+          deps = Set.new()
+          expand_package_deps(parent_name, @package_names, deps, distro)
+          core_deps[distro][parent_name] = deps
+        end
+      end
 
       packages_index = {}
       $all_distros.each do |distro|
@@ -1524,6 +1555,12 @@ def generate_sorted_paginated(site, elements_sorted, default_sort_key, n_element
             readme_filtered = self.strip_stopwords(readmes_text)
 
             index += 1
+            core = ''
+            core_packages.each do |parent_name|
+              if core.empty? and core_deps[distro][parent_name].include?(package_name) then
+                core = parent_name
+              end
+            end
             packages_index[distro] << {
               'id' => index,
               'baseurl' => site.config['baseurl'],
@@ -1532,6 +1569,7 @@ def generate_sorted_paginated(site, elements_sorted, default_sort_key, n_element
               'tags' => (p['tags'] + package_name.split('_')) * " ",
               'package' => package_name,
               'repo' => repo.name,
+              'core' => core,
               'released' => if repo_snapshot.released then 'released' else '' end,
               'version' => p['version'],
               'description' => p['description'].strip,
@@ -1554,7 +1592,7 @@ def generate_sorted_paginated(site, elements_sorted, default_sort_key, n_element
       reference_field = 'id'
       indexed_fields = [
         'tags:100', 'package:100', 'description:50', 'maintainers', 'authors',
-        'readme', 'released', 'org', 'repo'
+        'readme', 'released', 'org', 'repo', 'core'
       ]
       site.static_files.push(*precompile_lunr_index(
         site, packages_index, reference_field, indexed_fields,

--- a/help/package_list.md
+++ b/help/package_list.md
@@ -14,6 +14,7 @@ breadcrumbs: ['help']
 - Package: Package name.
 - Description: Package description.
 - Release status (★): Release status of the package. A checkmark signifies the package is released.
+- Core (⊙): Is this a dependency of a core package? (a dependent of ros_core, ros_base, desktop, or desktop_full).
 - Last commit date (📅): The last date a commit was made to the package's repository.
 - Package dependency count (⬅): How many packages this package depends on.
 - Package used by count(➡): How many packages use this package as a dependency.
@@ -33,6 +34,7 @@ The package name is split by underscore (_), and those individual terms are adde
 **rosindex** searches the following fields within packages. These fields are also displayed, see above for their description:
 - package
 - description
+- core
 - maintainers
 - authors
 - repo


### PR DESCRIPTION
When searching for interesting packages, whether a package is part of a standard ROS build can be interesting. This PR includes a package column that shows this. It does that by looking for dependencies of the meta package ros_base.

There could be other choices for the parent, including ros_core, desktop, or desktop_full. IMHO ros_base is the best choice for this, but I would be open to other opinions. In terms of downloads, I maintain average package download counts for three months at https://rkent.github.io/ros_webdata/averaged_counts-2025-03.json. ros_base has the highest download count, though ros_core and desktop are close.

The first commit adds the ability to force includes of certain repos (so even in debug builds we get ros_base), while the second adds the column.

There are a couple of minor drive-by changes: a minor comment correction, plus I added variable names to all tooltips, since it seemed to be needed on this ros_base column.

A full build with this feature included (with a possibly trivially earlier version) is at https://pr-rosindex.rosdabbler.com/