### PR TITLE
Use correct instance for repo url

### DIFF
--- a/_layouts/search_packages.html
+++ b/_layouts/search_packages.html
@@ -264,7 +264,7 @@ layout: default
         headerTooltip:"last commit date", sorter:"date", sorterParams:{format:"yyyy-MM-dd"}
       };
     repoColumn =
-      { title:"Repo", field:"repo", width:100,
+      { title:"Repo", field:"instance", width:100,
         formatter:"link", formatterParams:{labelField:"repo", url:(cell) => {
           return `{{site.baseurl}}/r/${cell.getValue()}/#${distro}`}}
       };
@@ -285,6 +285,7 @@ layout: default
       { title:"Maintainers", field:"maintainers", width:120},
       { title:"Org", field:"org", width:100},
       { title:"score", field:"score", width:60, sorter:"number", visible:false},
+      { title:"instance", field:"instance", width:100, visible:false},
     ];
 
     if (isRepos) {

--- a/_plugins/rosindex_generator.rb
+++ b/_plugins/rosindex_generator.rb
@@ -1576,7 +1576,7 @@ def generate_sorted_paginated(site, elements_sorted, default_sort_key, n_element
               'maintainers' => p['maintainers'] * ", ",
               'authors' => p['authors'] * ", ",
               'distro' => distro,
-              'instance' => repo.id,
+              'instance' => repo.name + '/' + repo.id,
               'pkg_deps' => p['pkg_deps'].length,
               'dependants' => p['dependants'].length,
               'readme' => readme_filtered,


### PR DESCRIPTION
This PR corrects a problem when there are multiple instances of a repo url. Previously, the link from the package list page to the repo did not include the instance, so the effect was it chose the default repo. Multiple repo instances typically occur when there are are different repo instances for different distros. What would happen is, if the current distro did not use the default repo, then when you clicked on the repo it would show that the repo was not available in that distro. You would have to use the repo instance UI to find the correct repo. With this PR, the correct repo instance is displayed.

An example is aruco_opencv.  If you find this on Noetic and click on the repo, it will claim to be unavailable for Noetic.