### PR TITLE
Sort distro overlaps in stats to prevent ordering error

### DIFF
--- a/_ruby_libs/pages.rb
+++ b/_ruby_libs/pages.rb
@@ -237,7 +237,7 @@ class StatsPage < Jekyll::Page
 
     # compute venn diagram model
     distro_counts = Hash[$recent_distros.collect { |d| [d, 0] }]
-    distro_overlaps = Hash[(2..$recent_distros.length).flat_map{|n| $recent_distros.combination(n).to_a}.collect { |s| [s, 0] }]
+    distro_overlaps = Hash[(2..$recent_distros.length).flat_map{|n| $recent_distros.combination(n).to_a}.collect { |s| [s.sort, 0] }]
     puts 'distro_overlaps: ' + distro_overlaps.to_s
 
     package_names.each do |package_name, package_instances|
@@ -249,6 +249,7 @@ class StatsPage < Jekyll::Page
           distro_counts[distro] += 1
         end
       end
+      overlap = overlap.sort
 
       puts package_name.to_s + " " + overlap.to_s
 


### PR DESCRIPTION
As noted in #517, there is an ordering issue in the definition of the Hash used for stats. I don't really understand why I was seeing a failure on my builds but not on the buildfarm, but it is likely to depend on the order in which packages are processed.

In any case the `combination` method in Ruby states that order of entries is indeterminate, whereas previously rosindex required a specific order so that the hash matched. This PR sorts those arrays that are used as Hash keys to prevent this problem. My builds are now working with this change.