### PR TITLE
Remove pagination of all things except the contributions

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -103,9 +103,7 @@ old_ros_distros:
   - 'kinetic'
   - 'melodic'
 
-# package list page
-packages_per_page: 200
-repos_per_page: 200
+contributions_per_page: 200
 
 # set the following to a non-zero value for testing (limit the number of indexed repos)
 max_repos: 00

--- a/_config_devel.yml
+++ b/_config_devel.yml
@@ -1,7 +1,3 @@
-# package list page
-packages_per_page: 5
-repos_per_page: 5
-
 # set the following to a non-zero value for testing (limit the number of indexed repos)
 max_repos: 10
 

--- a/_plugins/rosindex_generator.rb
+++ b/_plugins/rosindex_generator.rb
@@ -848,21 +848,6 @@ class Indexer < Jekyll::Generator
     site.pages << SearchDepsListPage.new(site)
   end
  
-  def generate_sorted_paginated_deps(site, elements_sorted, default_sort_key, n_elements, elements_per_page, page_class)
-
-    n_pages = (n_elements / elements_per_page).floor + 1
-
-    (1..n_pages).each do |page_index|
-      p_start = (page_index-1) * elements_per_page
-      elements_sliced = elements_sorted.slice(p_start, elements_per_page)
-      site.pages << page_class.new(site, default_sort_key, n_pages, page_index, elements_sliced)
-      # create page 1 without a page number or key in the url
-      if page_index == 1
-        site.pages << page_class.new(site, default_sort_key, n_pages, page_index, elements_sliced, true)
-      end
-    end
-  end
-
   def generate_sorted_paginated(site, elements_sorted, default_sort_key, n_elements, elements_per_page, page_class)
 
     n_pages = (n_elements / elements_per_page).floor + 1

--- a/_plugins/rosindex_generator.rb
+++ b/_plugins/rosindex_generator.rb
@@ -863,7 +863,7 @@ class Indexer < Jekyll::Generator
     end
   end
 
-def generate_sorted_paginated(site, elements_sorted, default_sort_key, n_elements, elements_per_page, page_class)
+  def generate_sorted_paginated(site, elements_sorted, default_sort_key, n_elements, elements_per_page, page_class)
 
     n_pages = (n_elements / elements_per_page).floor + 1
 

--- a/_plugins/rosindex_generator.rb
+++ b/_plugins/rosindex_generator.rb
@@ -1471,14 +1471,8 @@ class Indexer < Jekyll::Generator
       site.pages << PackagePage.new(site, package_instances)
     end
 
-    # create repo list pages
-    puts ("Generating repo list pages...").blue
-
-    repos_sorted = sort_repos(site)
-    generate_sorted_paginated(site, repos_sorted, 'time', @repo_names.length, site.config['repos_per_page'], RepoListPage)
-
-    # create package list pages
-    puts ("Generating package list pages...").blue
+    # create system dependency list pages
+    puts ("Generating system dependency list pages...").blue
 
     generate_search_deps_list(site)
 

--- a/_plugins/rosindex_generator.rb
+++ b/_plugins/rosindex_generator.rb
@@ -1487,7 +1487,7 @@ class Indexer < Jekyll::Generator
     puts ("Generating contribution suggestions list page...").blue
 
     suggestions_sorted = sort_repos_filtered(site, site.config['contribute_suggested_repos'])
-    generate_sorted_paginated(site, suggestions_sorted, 'name', suggestions_sorted['name'].length, site.config['repos_per_page'], ContributionSuggestionsPage)
+    generate_sorted_paginated(site, suggestions_sorted, 'name', suggestions_sorted['name'].length, site.config['contributions_per_page'], ContributionSuggestionsPage)
 
     # populate the home page with available distros
     site.pages << HomePage.new(site)

--- a/_ruby_libs/pages.rb
+++ b/_ruby_libs/pages.rb
@@ -123,35 +123,6 @@ class SearchDepsListPage < Jekyll::Page
   end
 end
 
-class RepoListPage < Jekyll::Page
-  def initialize(site, sort_id, n_list_pages, page_index, list, default=false)
-    @site = site
-    @base = site.source
-    @dir = unless default then 'repos/page/'+page_index.to_s+'/'+sort_id else 'repos' end
-    @name = 'index.html'
-
-    self.process(@name)
-    self.read_yaml(File.join(@base, '_layouts'),'repos.html')
-    self.data['pager'] = {
-      'base' => 'repos',
-      'post_ns' => '/'+sort_id
-    }
-    self.data['sort_id'] = sort_id
-    self.data['n_list_pages'] = n_list_pages
-    self.data['page_index'] = page_index
-    self.data['list'] = list
-
-    self.data['prev_page'] = [page_index - 1, 1].max
-    self.data['next_page'] = [page_index + 1, n_list_pages].min
-
-    self.data['near_pages'] = *([1,page_index-4].max..[page_index+4, n_list_pages].min)
-    self.data['all_distros'] = site.config['distros'] + site.config['old_distros']
-
-    self.data['available_distros'] = Hash[site.config['distros'].collect { |d| [d, true] }]
-    self.data['available_older_distros'] = Hash[site.config['old_distros'].collect { |d| [d, true] }]
-    self.data['n_available_older_distros'] = site.config['old_distros'].length
-  end
-end
 
 class PackagePage < Jekyll::Page
   def initialize(site, package_instances)


### PR DESCRIPTION
The repo and package lists are now in a responsive table instead. 

The Contributions list is still there, and needs to be reviewed/cleared but we can do that separately. 

This is stripping the separable parts out of #521 that aren't blocked on improved distro based logic. 