### PR TITLE
Update canonical links with redirect

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem 'colorator'
 gem 'github-markup'
 gem 'jekyll'
 gem "jekyll-include-cache"
+gem "jekyll-redirect-from"
 gem 'jekyll-sitemap'
 gem 'liquid'#, '~> 2.6.2'
 gem 'mercurial-ruby'

--- a/_config.yml
+++ b/_config.yml
@@ -9,6 +9,7 @@ kramdown:
 
 profile: true
 
+url: "https://index.ros.org" # the base hostname & protocol for your site
 google_analytics_tag_id: 'G-EVD5Z6G6NH'
 
 # OLD from jekyll 2.x
@@ -112,6 +113,7 @@ max_repos: 00
 
 plugins:
   - jekyll-include-cache
+  - jekyll-redirect-from
   - jekyll-sitemap
 
 # Repos to list as suggestiong on the "contribute" page

--- a/_config_devel.yml
+++ b/_config_devel.yml
@@ -1,3 +1,6 @@
+# unset url for devel env 
+url: "http://localhost:4000" # the base hostname & protocol for your site
+
 # package list page
 packages_per_page: 5
 repos_per_page: 5

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,7 +16,7 @@
       window.location.href = "{{ page.canonical_url | replace: 'index.html','' }}";
     </script>
     {% else %}
-    <link rel="canonical" href="{{ page.url | replace: 'index.html', '' | prepend: site.baseurl | prepend: site.url }}">
+    <link rel="canonical" href="{{ page.url | prepend: site.baseurl | prepend: site.url }}">
     {% endif %}
     
     <link rel="icon" sizes="any" type="image/svg+xml" href="{{ site.baseurl }}/assets/rosindex_logo.svg">

--- a/_ruby_libs/pages.rb
+++ b/_ruby_libs/pages.rb
@@ -22,7 +22,7 @@ end
 class DepPage < Jekyll::Page
   def initialize(site, dep_name, dep_data, full_dep_data)
 
-    basepath = File.join('d', dep_name)
+    basepath = File.join('d', dep_name).gsub('.','_') # Sanitize for period in the key which causes unintended extensions
 
     @site = site
     @base = site.source
@@ -32,6 +32,7 @@ class DepPage < Jekyll::Page
     self.process(@name)
     self.read_yaml(File.join(@base, '_layouts'),'dep.html')
     self.data['permalink'] = @dir
+    self.data['redirect_from'] = [self.data['permalink'] + '/']
 
     self.data['dep_name'] = dep_name
     self.data['dep_data'] = dep_data
@@ -54,6 +55,7 @@ class RepoInstancesPage < Jekyll::Page
     self.read_yaml(File.join(@base, '_layouts'),'repo_instances.html')
     self.data['repo_instances'] = repo_instances
     self.data['permalink'] = @dir
+    self.data['redirect_from'] = [self.data['permalink'] + '/']
   end
 end
 
@@ -70,6 +72,8 @@ class RepoPage < Jekyll::Page
 
     self.process(@name)
     self.read_yaml(File.join(@base, '_layouts'),'repo_instance.html')
+    self.data['permalink'] = @dir
+    self.data['redirect_from'] = [self.data['permalink'] + '/']
 
     self.data['instance'] =   repo
     self.data['repo'] =   repo
@@ -119,6 +123,7 @@ class SearchDepsListPage < Jekyll::Page
     self.process(@name)
     self.read_yaml(File.join(@base, '_layouts'),'search_deps.html')
     self.data['permalink'] = @dir
+    self.data['redirect_from'] = [self.data['permalink'] + '/']
     self.data['pager'] = {
       'base' => 'packages',
       'post_ns' => '/'
@@ -136,7 +141,8 @@ class RepoListPage < Jekyll::Page
 
     self.process(@name)
     self.read_yaml(File.join(@base, '_layouts'),'repos.html')
-    self.data['permalink'] = unless default then 'repos/page/'+page_index.to_s+'/'+sort_id else 'repos' end
+    self.data['permalink'] = @dir
+    self.data['redirect_from'] = [self.data['permalink'] + '/']
     self.data['pager'] = {
       'base' => 'repos',
       'post_ns' => '/'+sort_id
@@ -167,7 +173,8 @@ class PackagePage < Jekyll::Page
 
     self.process(@name)
     self.read_yaml(File.join(@base, '_layouts'),'package.html')
-    self.data['permalink'] = File.join('p',package_instances.name)
+    self.data['permalink'] = @dir
+    self.data['redirect_from'] = [self.data['permalink'] + '/']
     self.data['package_instances'] = package_instances
     self.data['package_name'] = package_instances.name
     self.data['title'] = 'ROS Package: ' + package_instances.name
@@ -188,44 +195,6 @@ class PackagePage < Jekyll::Page
   end
 end
 
-class PackageInstancePage < Jekyll::Page
-  def initialize(site, package_instances, instance, package_name)
-
-    @site = site
-    @base = site.source
-    @dir = File.join('p', package_name, instance.id)
-    @name = 'index.html'
-
-    self.process(@name)
-    self.read_yaml(File.join(@base, '_layouts'),'package_instance.html')
-    self.data['permalink'] = File.join('p', package_name, instance.id)
-
-    self.data['instances'] = package_instances.instances
-    self.data['instance'] = instance
-    self.data['package_name'] = package_name
-    self.data['title'] = 'ROS Package: ' + package_name
-
-    self.data['instance_index_url'] = ['packages',package_instances.name].join('/')
-    self.data['instance_base_url'] = ['p',package_name].join('/')
-
-    self.data['available_distros'] = {}
-    self.data['available_older_distros'] = {}
-    instance.snapshots.each do |distro, snapshot|
-      if site.config['distros'].include? distro
-        self.data['available_distros'][distro] = snapshot.packages.key?(package_name)
-      else
-        self.data['available_older_distros'][distro] = snapshot.packages.key?(package_name)
-      end
-    end
-    self.data['n_available_older_distros'] = self.data['available_older_distros'].values.count(true)
-
-    self.data['all_distros'] = site.config['distros'] + site.config['old_distros']
-
-    self.data['default_distro'] = self.data['available_distros'].keys.first or
-                                  self.data['available_older_distros'].keys.first or
-                                  self.data['all_distros'].first
-  end
-end
 
 class StatsPage < Jekyll::Page
   def initialize(site, package_names, all_repos, errors)
@@ -237,7 +206,8 @@ class StatsPage < Jekyll::Page
 
     self.process(@name)
     self.read_yaml(File.join(@base, '_layouts'),'stats.html')
-    self.data['permalink'] = 'stats'
+    self.data['permalink'] = @dir
+    self.data['redirect_from'] = [self.data['permalink'] + '/']
 
     self.data['n_packages'] = package_names.length
     self.data['n_repos'] = all_repos.length
@@ -294,7 +264,9 @@ class ContributionSuggestionsPage < Jekyll::Page
 
     self.process(@name)
     self.read_yaml(File.join(@base, '_layouts'),'contribution_suggestions.html')
-    self.data['permalink'] = unless default then 'contribute/suggestions/page/'+page_index.to_s+'/'+sort_id else 'contribute/suggestions' end
+    self.data['permalink'] = @dir
+    self.data['redirect_from'] = [self.data['permalink'] + '/']
+
     self.data['pager'] = {
       'base' => 'contribute/suggestions',
       'post_ns' => '/'+sort_id

--- a/_ruby_libs/pages.rb
+++ b/_ruby_libs/pages.rb
@@ -31,6 +31,7 @@ class DepPage < Jekyll::Page
 
     self.process(@name)
     self.read_yaml(File.join(@base, '_layouts'),'dep.html')
+    self.data['permalink'] = @dir
 
     self.data['dep_name'] = dep_name
     self.data['dep_data'] = dep_data
@@ -52,6 +53,7 @@ class RepoInstancesPage < Jekyll::Page
     self.process(@name)
     self.read_yaml(File.join(@base, '_layouts'),'repo_instances.html')
     self.data['repo_instances'] = repo_instances
+    self.data['permalink'] = @dir
   end
 end
 
@@ -71,6 +73,7 @@ class RepoPage < Jekyll::Page
 
     self.data['instance'] =   repo
     self.data['repo'] =   repo
+    self.data['permalink'] = @dir
 
     self.data['instances'] = instances.instances
     self.data['instance_base_url'] = basepath
@@ -110,11 +113,12 @@ class SearchDepsListPage < Jekyll::Page
   def initialize(site)
     @site = site
     @base = site.source
-    @dir = 'search_deps/'
+    @dir = 'search_deps'
     @name = 'index.html'
-
+    
     self.process(@name)
     self.read_yaml(File.join(@base, '_layouts'),'search_deps.html')
+    self.data['permalink'] = @dir
     self.data['pager'] = {
       'base' => 'packages',
       'post_ns' => '/'
@@ -132,6 +136,7 @@ class RepoListPage < Jekyll::Page
 
     self.process(@name)
     self.read_yaml(File.join(@base, '_layouts'),'repos.html')
+    self.data['permalink'] = unless default then 'repos/page/'+page_index.to_s+'/'+sort_id else 'repos' end
     self.data['pager'] = {
       'base' => 'repos',
       'post_ns' => '/'+sort_id
@@ -162,6 +167,7 @@ class PackagePage < Jekyll::Page
 
     self.process(@name)
     self.read_yaml(File.join(@base, '_layouts'),'package.html')
+    self.data['permalink'] = File.join('p',package_instances.name)
     self.data['package_instances'] = package_instances
     self.data['package_name'] = package_instances.name
     self.data['title'] = 'ROS Package: ' + package_instances.name
@@ -192,6 +198,7 @@ class PackageInstancePage < Jekyll::Page
 
     self.process(@name)
     self.read_yaml(File.join(@base, '_layouts'),'package_instance.html')
+    self.data['permalink'] = File.join('p', package_name, instance.id)
 
     self.data['instances'] = package_instances.instances
     self.data['instance'] = instance
@@ -230,6 +237,7 @@ class StatsPage < Jekyll::Page
 
     self.process(@name)
     self.read_yaml(File.join(@base, '_layouts'),'stats.html')
+    self.data['permalink'] = 'stats'
 
     self.data['n_packages'] = package_names.length
     self.data['n_repos'] = all_repos.length
@@ -286,6 +294,7 @@ class ContributionSuggestionsPage < Jekyll::Page
 
     self.process(@name)
     self.read_yaml(File.join(@base, '_layouts'),'contribution_suggestions.html')
+    self.data['permalink'] = unless default then 'contribute/suggestions/page/'+page_index.to_s+'/'+sort_id else 'contribute/suggestions' end
     self.data['pager'] = {
       'base' => 'contribute/suggestions',
       'post_ns' => '/'+sort_id
@@ -334,6 +343,7 @@ class ErrorsPage < Jekyll::Page
 
     self.process(@name)
     self.read_yaml(File.join(@base, '_layouts'),'errors.html')
+    self.data['permalink'] = File.join('stats','errors')
     self.data['errors'] = []
 
     errors.each do |name, repo_errors|

--- a/index.yml
+++ b/index.yml
@@ -4,7 +4,6 @@ title: ROS Index
 description: > # this means to ignore newlines until "baseurl:"
   a community-maintained index of robotics software
 baseurl: "" # the subpath of your site, e.g. /blog/
-url: "https://index.ros.org" # the base hostname & protocol for your site
 #twitter_username: jekyllrb
 github_username:  ros-infrastructure/rosindex
 # keep_files: [cache, .git]


### PR DESCRIPTION
This is everything for #520 but it doesn't work on my local testing because it seems that the `jekyll serve` is providing the folder contents in preference to the file contents 

You can see below 

The files are correctly:
`stats.html` is the content with canonical `/stats`
`stats/index.html` is the redirect and served at `/stats/` pointing to `/stats`

However when querying for `/stats` it serves the redirect from `stats/index.html` instead of the content from `stats.html`

Which means that you end up in an infinite redirect loop.


```
tullyfoote@tullyfoote-glaptop:~/ws/rosindex/rosindex$ curl -L localhost:4000/stats.html | head -n 25
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 22364  100 22364    <!DOCTYPE html>     0 --:--:-- --:--:-- --:--:--     0
0<html>
 
  <head>
    <meta charset="utf-8">
    <meta name="viewport" content="width=device-width initial-scale=1" />
    <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
     <title>ROS Index</title>
     <meta name="description" content="a community-maintained index of robotics software
 ">
0
     
     <link rel="canonical" href="http://localhost:4000/stats">
1    
4    
.    <link rel="icon" sizes="any" type="image/svg+xml" href="/assets/rosindex_logo.svg">

1    
M
     <link rel="stylesheet" type="text/css" href="/bootstrap/css/bootstrap.min.css"/>
     <link rel="stylesheet" href="/css/main.css">
     
 
     
 0 --:--:-- --:--:-- --:--:-- 21.3M
curl: Failed writing body
tullyfoote@tullyfoote-glaptop:~/ws/rosindex/rosindex$ curl -L localhost:4000/stats/
<!DOCTYPE html>
<html lang="en-US">
  <meta charset="utf-8">
  <title>Redirecting&hellip;</title>
  <link rel="canonical" href="http://localhost:4000/stats">
  <script>location="http://localhost:4000/stats"</script>
  <meta http-equiv="refresh" content="0; url=http://localhost:4000/stats">
  <meta name="robots" content="noindex">
  <h1>Redirecting&hellip;</h1>
  <a href="http://localhost:4000/stats">Click here if you are not redirected.</a>
</html>
tullyfoote@tullyfoote-glaptop:~/ws/rosindex/rosindex$ curl -L localhost:4000/stats
<!DOCTYPE html>
<html lang="en-US">
  <meta charset="utf-8">
  <title>Redirecting&hellip;</title>
  <link rel="canonical" href="http://localhost:4000/stats">
  <script>location="http://localhost:4000/stats"</script>
  <meta http-equiv="refresh" content="0; url=http://localhost:4000/stats">
  <meta name="robots" content="noindex">
  <h1>Redirecting&hellip;</h1>
  <a href="http://localhost:4000/stats">Click here if you are not redirected.</a>
</html>
tullyfoote@tullyfoote-glaptop:~/ws/rosindex/rosindex$ head -n 20 _site/stats/index.html
<!DOCTYPE html>
<html lang="en-US">
  <meta charset="utf-8">
  <title>Redirecting&hellip;</title>
  <link rel="canonical" href="http://localhost:4000/stats">
  <script>location="http://localhost:4000/stats"</script>
  <meta http-equiv="refresh" content="0; url=http://localhost:4000/stats">
  <meta name="robots" content="noindex">
  <h1>Redirecting&hellip;</h1>
  <a href="http://localhost:4000/stats">Click here if you are not redirected.</a>
</html>
tullyfoote@tullyfoote-glaptop:~/ws/rosindex/rosindex$ head -n 20 _site/stats.html 
<!DOCTYPE html>
<html>

  <head>
    <meta charset="utf-8">
    <meta name="viewport" content="width=device-width initial-scale=1" />
    <meta http-equiv="X-UA-Compatible" content="IE=edge">

    <title>ROS Index</title>
    <meta name="description" content="a community-maintained index of robotics software
">

    
    <link rel="canonical" href="http://localhost:4000/stats">
    
    
    <link rel="icon" sizes="any" type="image/svg+xml" href="/assets/rosindex_logo.svg">
```
