### PR TITLE
Download debian descriptions in a separate process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,22 +16,32 @@ scrape_config=_config/scrape.yml
 search_config=_config/search_index.yml
 
 .DEFAULT_GOAL := build
-.PHONY: build rebuild-pip-descriptions prepare-sources discover update scrape serve serve-devel test-build clean-sources clean-cache clean
+.PHONY: build rebuild-dep-descriptions prepare-sources discover \
+        update scrape serve serve-devel test-build clean-sources clean-cache clean
+
 PIP_FILE := _artifacts/pip_packages.json
 PIP_SCRIPT := _scripts/pip_packages.py
+DEBIAN_FILE := _artifacts/debian_packages.json
+DEBIAN_SCRIPT := _scripts/debian_descriptions.rb
 
 $(PIP_FILE):
 	@echo "Get pip descriptions file"
 	python3 $(PIP_SCRIPT)
 
-rebuild-pip-descriptions:
+rebuild-dep-descriptions:
 	@echo "rebuild pip descriptions file"
 	python3 $(PIP_SCRIPT)
+	@echo "rebuild debian descriptions file"
+	ruby $(DEBIAN_SCRIPT)
 
-build: rebuild-pip-descriptions prepare-sources
+$(DEBIAN_FILE):
+	@echo "Get debian descriptions file"
+	ruby $(DEBIAN_SCRIPT)
+
+build: rebuild-dep-descriptions prepare-sources
 	bundle exec jekyll build --verbose --trace -d $(site_path) --config=$(config_file),$(index_file)
 
-prepare-sources: $(PIP_FILE)
+prepare-sources: $(PIP_FILE) $(DEBIAN_FILE)
 	mkdir -p $(remotes_dir)
 	vcs import --input $(remotes_file) --force $(remotes_dir)
 	vcs pull $(remotes_dir)

--- a/_plugins/rosindex_generator.rb
+++ b/_plugins/rosindex_generator.rb
@@ -922,6 +922,8 @@ class Indexer < Jekyll::Generator
     @wiki_data = {}
 
     # load rosdep data
+    puts ("Loading ros dependencies").green
+
     # TODO: check deps against this when generating pages
     rosdep_path = site.config.key?('rosdep_path') ? site.config['rosdep_path']: site.config['rosdistro_paths'].first
 
@@ -975,6 +977,7 @@ class Indexer < Jekyll::Generator
 
     # get the repositories from the rosdistro files, rosdoc rosinstall files, and other sources
     unless @skip_discover
+      puts ("Doing discovery").green
 
       # read in rosdistro sources
       $all_distros.reverse_each do |distro|

--- a/_ruby_libs/dependency_descriptions.rb
+++ b/_ruby_libs/dependency_descriptions.rb
@@ -16,48 +16,21 @@ require 'json'
 require 'net/http'
 require 'uri'
 
-DEBIAN_URL = 'https://packages.debian.org/stable/allpackages?format=txt.gz'
 PIP_FILE = '_artifacts/pip_packages.json'
+DEBIAN_FILE = '_artifacts/debian_packages.json'
+
 
 def get_debian_descriptions()
-    # Loads descriptions of debian packages from a debian index.
-    # Returned file gives description indexed by debian package name.
-    content_unicode = nil
-    retry_delay = [0, 10, 60]
-    retry_delay.each_with_index do |delay, idx|
-        if delay != 0 then sleep(delay) end
-        begin
-            content_unicode = Net::HTTP.get(URI(DEBIAN_URL))
-            break
-        rescue StandardError => error
-            puts 'WARNING: Debian packages description download error: #{error}'
-            if idx < retry_delay.length - 1
-                puts 'Retrying debian description download'
-                next
-            else
-                puts 'Failing debian description download'
-            end
-        end
+    # Get debian descriptions from a file.
+    # Returned descriptions are indexed by debian package name.
+    if File.exist?(DEBIAN_FILE)
+        puts 'Reading debian descriptions from saved file'.green
+        debian_descriptions_json = File.read(DEBIAN_FILE)
+        return JSON.parse(debian_descriptions_json)
+    else
+        puts 'Debian descriptions file does not exist, continuing with no debian descriptions'.red
+        return {}
     end
-
-    packages = {}
-    # Test for failed download
-    if !content_unicode then return packages end
-
-    # The package file seems to have unicode that confuses ruby. Just force to ascii.
-    content = content_unicode.encode('US-ASCII', invalid: :replace, undef: :replace)
-    content.lines.each do |line|
-        # Typical package line:
-        # 3270-common (4.1ga10-1.1+b1) Common files for IBM 3270 emulators and pr3287
-        left_paren = line.index('(')
-        right_paren = line.index(')')
-        # The file starts with some beginning material that is not packages.
-        if not left_paren or not right_paren then next end
-        package_name = line[0..left_paren - 2]
-        package_desc = line[right_paren + 2..line.length - 1]
-        packages[package_name] = package_desc
-    end
-    packages
 end
 
 

--- a/_scripts/debian_descriptions.rb
+++ b/_scripts/debian_descriptions.rb
@@ -1,0 +1,74 @@
+#!/usr/bin/env ruby
+# Copyright 2024 R. Kent James
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'json'
+require 'net/http'
+require 'uri'
+
+DEBIAN_URL = 'https://packages.debian.org/stable/allpackages?format=txt.gz'
+DEBIAN_FILE = '_artifacts/debian_packages.json'
+
+
+def load_debian_descriptions()
+    # Loads descriptions of debian packages from a debian index.
+    # Returned file gives description indexed by debian package name.
+    content_unicode = nil
+    retry_delay = [0, 10, 60]
+    retry_delay.each_with_index do |delay, idx|
+        if delay != 0 then sleep(delay) end
+        begin
+            puts "Downloading debian package descriptions"
+            content_unicode = Net::HTTP.get(URI(DEBIAN_URL))
+            break
+        rescue StandardError => error
+            puts 'WARNING: Debian packages description download error: #{error}'
+            if idx < retry_delay.length - 1
+                puts 'Retrying debian description download'
+                next
+            else
+                puts 'Failing debian description download'
+            end
+        end
+    end
+
+    # Test for failed download
+    if !content_unicode then return nil end
+
+    packages = {}
+    # The package file seems to have unicode that confuses ruby. Just force to ascii.
+    content = content_unicode.encode('US-ASCII', invalid: :replace, undef: :replace)
+    content.lines.each do |line|
+        # Typical package line:
+        # 3270-common (4.1ga10-1.1+b1) Common files for IBM 3270 emulators and pr3287
+        left_paren = line.index('(')
+        right_paren = line.index(')')
+        # The file starts with some beginning material that is not packages.
+        if not left_paren or not right_paren then next end
+        package_name = line[0..left_paren - 2]
+        package_desc = line[right_paren + 2..line.length - 1]
+        packages[package_name] = package_desc
+    end
+    packages
+end
+
+if __FILE__ == $0
+    packages = load_debian_descriptions()
+
+    if packages then
+        File.open(DEBIAN_FILE, 'w') do |f|
+            f.write(packages.to_json)
+        end
+    end
+end


### PR DESCRIPTION
This PR changes the handling of debian descriptions to match the handling of pip descriptions, using the Makefile. Because the reading of debian descriptions is quite fast, I did not see the need for a separate makefile target for that, so I just merged it with the pip descriptions rebuild.

This is part of trying to reduce the work done by the rosindex generator.