### PR TITLE
Fallback to showing something not nothing

### DIFF
--- a/_includes/package_header.html
+++ b/_includes/package_header.html
@@ -25,6 +25,9 @@ Assumes the following are defined:
             {% endif %}
           {% endfor %}
       </td>
+      <td width="100px" class="text-center">
+        <h3 style="margin-top: 5px"><small> ROS Distro</small><br>{{rendered_distro}}</h3>
+      </td>
     </tr>
   </table>
 </div>

--- a/_includes/package_header.html
+++ b/_includes/package_header.html
@@ -3,7 +3,7 @@ Assumes the following are defined:
  - package
  - instance
  - distro
- - show_repo
+ - rendered_distro
 {% endcomment %}
 
 <div class="well well-sm">

--- a/_layouts/package.html
+++ b/_layouts/package.html
@@ -23,30 +23,37 @@ layout: default
 {% for distro in page.all_distros %}
   <div class="distro distro-{{distro}}">
     <div class="container-fluid">
-      {% if page.available_distros[distro] or page.available_older_distros[distro] %}
-        {% assign package = page.package_instances.snapshots[distro] %}
-        {% assign instance = page.package_instances.repos[distro] %}
-        {% assign show_repo = false %}
+      {% unless page.available_distros[distro] or page.available_older_distros[distro] %}
+        {% for fallback_distro in page.all_distros %}
+          {% if page.available_distros[fallback_distro] or page.available_older_distros[fallback_distro] %}
+            {% assign rendered_distro = fallback_distro %}
+            {% break %}
+          {% endif %}
+        {% endfor %}
+        <div class="alert alert-warning">No version for distro <strong>{{ distro }}</strong> showing <strong>{{ rendered_distro }}</strong>. Known supported distros are highlighted in the buttons above.</div>
+      {% else %}
+        {% assign rendered_distro = distro %}
+      {% endunless %}
+      {% assign package = page.package_instances.snapshots[rendered_distro] %}
+      {% assign instance = page.package_instances.repos[rendered_distro] %}
+      {% assign show_repo = false %}
 
-        <div class="row">
-          <div class="col-md-10">
-            {% include package_header.html %}
-            <div class="visible-xs visible-sm">
-              {% assign hide_link_labels = true %}
-              {% assign horizontal = true %}
-              {% include package_links.html %}
-            </div>
-            {% include package_body.html %}
-          </div>
-          <div class="col-md-2 hidden-xs hidden-sm">
-            {% assign hide_link_labels = false %}
-            {% assign horizontal = false %}
+      <div class="row">
+        <div class="col-md-10">
+          {% include package_header.html %}
+          <div class="visible-xs visible-sm">
+            {% assign hide_link_labels = true %}
+            {% assign horizontal = true %}
             {% include package_links.html %}
           </div>
+          {% include package_body.html %}
         </div>
-      {% else %}
-          <div class="alert alert-warning">No version for distro <strong>{{ distro }}</strong>. Known supported distros are highlighted in the buttons above.</div>
-      {% endif %}
+        <div class="col-md-2 hidden-xs hidden-sm">
+          {% assign hide_link_labels = false %}
+          {% assign horizontal = false %}
+          {% include package_links.html %}
+        </div>
+      </div>
     </div>
   </div>
 {% endfor %}

--- a/_layouts/package.html
+++ b/_layouts/package.html
@@ -36,7 +36,6 @@ layout: default
       {% endunless %}
       {% assign package = page.package_instances.snapshots[rendered_distro] %}
       {% assign instance = page.package_instances.repos[rendered_distro] %}
-      {% assign show_repo = false %}
 
       <div class="row">
         <div class="col-md-10">


### PR DESCRIPTION
This is a problem for our indexing as the indexer will see no content if the package isn't available on our default version.

So older packages or not maintained on rolling packages won't get indexed.