### PR TITLE
Remove any existing matching user in Dockerfile

### DIFF
--- a/docker/image/Dockerfile
+++ b/docker/image/Dockerfile
@@ -46,7 +46,8 @@ COPY docker/image/test_site.sh /usr/local/bin/test_site
 COPY docker/image/update_site.sh /usr/local/bin/update_site
 COPY docker/image/git_add_files.py /usr/local/bin/git_add_files
 
-RUN useradd -u $uid -m $user
+# Add requested user, removing any existing user with that UID.
+RUN if [ $(id -nu $uid) ]; then userdel -r $(id -nu $uid); fi && useradd -u $uid -m $user
 ENV HOME=/home/$user
 WORKDIR $HOME
 COPY Gemfile* .bundle/


### PR DESCRIPTION
If I run docker/build.sh now, it fails on my system since #534 since newer Ubuntu distributions include a standard user 1000. This PR applies the same fix that I did on the build_farm.