### PR TITLE
Update all package and repository cross references to end in trailing slash 

### DIFF
--- a/_includes/package_body.html
+++ b/_includes/package_body.html
@@ -238,11 +238,11 @@ Assumes distro and package are defined
                       <tr>
                         <td class="text-center">
                           {% assign n_2nd_order_deps = p[1].snapshots[distro].data.pkg_deps | size %}
-                          <a href="{{site.baseurl}}/p/{{p[0]}}#{{distro}}-deps" {% if n_2nd_order_deps == 0 %}class="endoftree"{% endif %}>
+                          <a href="{{site.baseurl}}/p/{{p[0]}}/#{{distro}}-deps" {% if n_2nd_order_deps == 0 %}class="endoftree"{% endif %}>
                             <span class="glyphicon glyphicon-arrow-left" title="Package dependencies"></span>
                           </a>
                         </td>
-                        <td><a href="{{site.baseurl}}/p/{{p[0]}}#{{distro}}">{{p[0]}} {{n_2nd_order_pdeps}} {{n_2nd_order_sdeps}}</a></td>
+                        <td><a href="{{site.baseurl}}/p/{{p[0]}}/#{{distro}}">{{p[0]}} {{n_2nd_order_pdeps}} {{n_2nd_order_sdeps}}</a></td>
                       </tr>
                     {% else %}
                       <tr>
@@ -304,10 +304,10 @@ Assumes distro and package are defined
                     {% assign dep_name = d[0] %}
                     {% for dep_instance in d[1] %}
                     <tr>
-                      <td><a href="{{site.baseurl}}/p/{{dep_name}}#{{distro}}">{{dep_name}}</a></td>
+                      <td><a href="{{site.baseurl}}/p/{{dep_name}}/#{{distro}}">{{dep_name}}</a></td>
                       <td class="text-center">
                         {% assign n_2nd_order_deps = dep_instance.package.data.dependants | size %}
-                        <a href="{{site.baseurl}}/p/{{dep_name}}#{{distro}}-deps" {% if n_2nd_order_deps == 0 %}class="endoftree"{% endif %}>
+                        <a href="{{site.baseurl}}/p/{{dep_name}}/#{{distro}}-deps" {% if n_2nd_order_deps == 0 %}class="endoftree"{% endif %}>
                           <span class="glyphicon glyphicon-arrow-right"></span>
                         </a>
                       </td>

--- a/_includes/package_header.html
+++ b/_includes/package_header.html
@@ -14,12 +14,12 @@ Assumes the following are defined:
       </td>
       <td>
         <h3 style="margin-top: 5px">
-          <a style="text-decoration:none" href="{{site.baseurl}}/p/{{package.name}}">{{package.name}}</a> <small>package from <a style="text-decoration:none" href="{{site.baseurl}}/r/{{ package.repo.name }}/{{ package.repo.id }}">{{ package.repo.name }}</a> repo</small>
+          <a style="text-decoration:none" href="{{site.baseurl}}/p/{{package.name}}/">{{package.name}}</a> <small>package from <a style="text-decoration:none" href="{{site.baseurl}}/r/{{ package.repo.name }}/{{ package.repo.id }}/">{{ package.repo.name }}</a> repo</small>
         </h3>
           {% for peer in package.snapshot.packages %}
             {% assign labeled_package = peer[1] %}
             {% if peer[0] != package.name %}
-              <a class="label label-primary pkg-label" href="{{site.baseurl}}/p/{{peer[0]}}">{{ labeled_package.data.name }}</a>
+              <a class="label label-primary pkg-label" href="{{site.baseurl}}/p/{{peer[0]}}/">{{ labeled_package.data.name }}</a>
             {% else %}
               <span class="label label-default pkg-label">{{ labeled_package.data.name }}</span>
             {% endif %}

--- a/_includes/repo_info.html
+++ b/_includes/repo_info.html
@@ -9,10 +9,10 @@
         <img style="width: 80px;" src="{{ '/assets/repo.png' | prepend: site.baseurl }}" alt="Repo symbol">
       </td>
       <td>
-        <h3><a style="text-decoration:none;" href="{{site.baseurl }}/r/{{page.repo.name}}">{{page.repo.name}}</a> <small>repository</small></h3>
+        <h3><a style="text-decoration:none;" href="{{site.baseurl }}/r/{{page.repo.name}}/">{{page.repo.name}}</a> <small>repository</small></h3>
         {% for tag in page.repo.tags %}<span class="label label-default">{{ tag }}</span> {% endfor %}
         {% for p in page.repo.snapshots[distro].packages %}
-        <a class="label label-primary pkg-label" href="{{site.baseurl}}/p/{{p[1].name}}">{{ p[1].name }}</a>
+        <a class="label label-primary pkg-label" href="{{site.baseurl}}/p/{{p[1].name}}/">{{ p[1].name }}</a>
         {% endfor %}
 
       </td>

--- a/_layouts/dep.html
+++ b/_layouts/dep.html
@@ -43,7 +43,7 @@ layout: default
           <th scope="row">{{distro}}</th>
           <td>
             {% for dependant in dependants %}
-            <a href="{{site.baseurl}}/p/{{dependant.package.name}}#{{distro}}" class="label label-primary pkg-label">
+            <a href="{{site.baseurl}}/p/{{dependant.package.name}}/#{{distro}}" class="label label-primary pkg-label">
               {{dependant.package.name}}
             </a>
             {% endfor %}

--- a/_layouts/errors.html
+++ b/_layouts/errors.html
@@ -31,7 +31,7 @@ layout: default
               {% for err in page.errors %}
                 <tr>
                   <td>
-                    <a href="{{site.baseurl}}/r/{{err.name}}">{{err.name}}</a>
+                    <a href="{{site.baseurl}}/r/{{err.name}}/">{{err.name}}</a>
                   </td>
                   <td>
                     <em>{{err.msg}}</em>

--- a/_layouts/repo_instance.html
+++ b/_layouts/repo_instance.html
@@ -49,7 +49,7 @@ layout: default
                 <tbody>
                 {% for p in page.repo.snapshots[distro].packages %}
                   <tr>
-                    <td><a href="{{site.baseurl}}/p/{{p[1].name}}">{{ p[1].name }}</a></td>
+                    <td><a href="{{site.baseurl}}/p/{{p[1].name}}/">{{ p[1].name }}</a></td>
                     <td>{{ p[1].data.version }}</td>
                   </tr>
                 {% endfor %}

--- a/_layouts/repo_instances.html
+++ b/_layouts/repo_instances.html
@@ -34,7 +34,7 @@ layout: default
             <tbody>
             {% for instance in page.repo_instances.instances %}
               <tr>
-                <td><a href="{{site.baseurl}}/r/{{page.repo_instances.name}}/{{instance[0]}}">{{ instance[0] }}</a></td>
+                <td><a href="{{site.baseurl}}/r/{{page.repo_instances.name}}/{{instance[0]}}/">{{ instance[0] }}</a></td>
                 <td class="filterable-cell"><a class="label label-primary pull-right" href="{{instance[1].uri}}">{{ instance[1].uri }}</a></td>
               </tr>
             {% endfor %}

--- a/about/design.md
+++ b/about/design.md
@@ -50,13 +50,13 @@ index.ros.org/r/<<REPOSITORY>>/<<INSTANCE>>/#<<DISTRO>>
 So for the ``geometry`` repository, the default instance would be resolved by:
 
 ```
-index.ros.org/r/geometry
+index.ros.org/r/geometry/
 ```
 
 In this case, this would be equivalent to:
 
 ```
-index.ros.org/r/geometry/github-ros-geometry
+index.ros.org/r/geometry/github-ros-geometry/
 ```
 
 This link would resolve to the repository corresponding to the URI given in the
@@ -93,13 +93,13 @@ index.ros.org/p/<<PACKAGE>>/<<INSTANCE>>/#<<DISTRO>>
 So for the ``tf`` package, the default instance would be resolved by:
 
 ```
-index.ros.org/p/tf
+index.ros.org/p/tf/
 ```
 
 In this case, this would be equivalent to:
 
 ```
-index.ros.org/p/tf/github-ros-geometry
+index.ros.org/p/tf/github-ros-geometry/
 ```
 
 When viewing the tab for a given ROS distribution, the user can see additional


### PR DESCRIPTION


This matches the canonical URL and will improve
our indexing as it won't create a large web of redirects.

This is the opposite of #524 but until that's resolved this will make things consistent with the canonical urls generated by jekyll avoiding all of our links not going to canonical urls. 