### PR TITLE
Remove tutorials tabs

### DIFF
--- a/_includes/package_body.html
+++ b/_includes/package_body.html
@@ -26,10 +26,6 @@ Assumes distro and package are defined
     <a href="#{{distro}}-deps" data-toggle="tab"><span class="label label-{%if n_deps == 0%}default{%else%}primary{%endif%}">{{n_deps}}</span> Dependencies</a>
   </li>
   <li class="better-tabs">
-    {% assign n_tutorials = package.data.wiki.tutorials | size %}
-    <a href="#{{distro}}-tutorials" data-toggle="tab"><span class="label label-{%if n_tutorials == 0%}default{%else%}primary{%endif%}">{{n_tutorials}}</span> Tutorials</a>
-  </li>
-  <li class="better-tabs">
     <a href="#{{distro}}-questions" data-toggle="tab"><span id="{{distro}}-questions-count" class="label label-primary">0</span> Q & A</a>
   </li>
 </ul>
@@ -192,27 +188,6 @@ Assumes distro and package are defined
             {% endif %}
           </div>
         </div>
-      </div>
-    </div>
-  </div>
-
-  <div class="tab-pane" id="{{distro}}-tutorials">
-    <div class="panel panel-default">
-      <div class="panel-heading">
-        <h3 class="panel-title">Wiki Tutorials</h3>
-      </div>
-      <div class="panel-body">
-        {% if n_tutorials > 0 %}
-          <ul>
-            {% for t in package.data.wiki.tutorials %}
-              <li><a href="http://wiki.ros.org/{{t[1]}}" target="_blank">{{t[0]}}</a></li>
-            {% endfor %}
-          </ul>
-          <br>
-        {% else %}
-        <em>This package does not provide any links to tutorials in it's <a href="https://index.ros.org/contribute/metadata/">rosindex metadata</a>.</em>
-        <em>You can check on the <a href="http://wiki.ros.org/{{package.name}}/Tutorials" target="_blank">ROS Wiki Tutorials</a> page for the package.</em>
-        {% endif %}
       </div>
     </div>
   </div>

--- a/contribute/metadata.md
+++ b/contribute/metadata.md
@@ -44,7 +44,6 @@ a ROS package:
 The following are ROS Index metadata elements which are either unimplemented or
 still being designed:
 
-* **Tutorials** -- `<tutorials>...</tutorials>`
 * **Nodes** -- `<nodes>...</nodes>`
 
 ### Category Tags
@@ -109,41 +108,6 @@ Standard readme filenames include (case-insensitive):
 Plaintext files and files without extensions will not be rendered, but will be
 shown as a single preformatted block. Markdown (`.md`) and RST (`.rst`)
 documents will be rendered into HTML.
-
-### Tutorials
-
-***WIP***
-
-A package can give a list of a series of tutorials with the
-following formats:
-
-```xml
-<tutorials>
-  <!-- Declare some pre-requisite tutorials -->
-  <prereq pkg="other_pkg"/>
-
-  <!-- Direct users to another package for tutorials. -->
-  <tutorial pkg="my_pkg_tutorials"/>
-
-  <!-- Direct users to a tutorial on an external website. -->
-  <tutorial link="http://www.my_website.com/some_tutorial.html">That Other Guy's Tutorial</tutorial>
-
-  <!-- Display markdown-based tutorials (rendered by ROSIndex). -->
-  <tutorial file="doc/tut1.md">Tutorial One</tutorial>
-  <tutorial file="doc/tut2.md">Tutorial Two</tutorial>
-  <tutorial file="doc/tut3.md">Tutorial Three</tutorial>
-
-  <!-- Display a group of markdown-based tutorials (rendered by ROSIndex). -->
-  <sequence title="Advanced Tutorials">
-    <tutorial file="doc/tut4.md">Tutorial Four</tutorial>
-    <tutorial file="doc/tut5.md">Tutorial Five</tutorial>
-    <tutorial file="doc/tut6.md">Tutorial Six</tutorial>
-  </sequence>
-</tutorials>
-```
-
-Tutorials listed on the ROS Wiki under `<<package_name>>/Tutorials/*`
-will also be listed and directly linked.
 
 ### Nodes
 

--- a/help/tutorial.md
+++ b/help/tutorial.md
@@ -13,7 +13,7 @@ There are thousands of ROS packages that encompass all aspects of robotics; ever
 Some of these packages exist solely as open source code, while others are distributed as binary packages that can be easily installed on a ROS system using tools like `apt`.
 This tool `ROS Index`,  is similar to [Python's Package Index (PyPI)](https://pypi.org).
 A good way to find a solution to many common robotics problems is to use ROS Index to find an appropriate ROS 2 binary package from the ROS ecosystem.
-Using ROS Index you can find binary ROS packages, the source code behind them, and their associated documentation and tutorials.
+Using ROS Index you can find binary ROS packages, the source code behind them, and their associated documentation.
 
 
 ## Searching for ROS Packages
@@ -34,7 +34,6 @@ After clicking the top package in the list, it will bring one to a page similar 
 ## Breaking it Down
 
 1. `Package Description` The general description of the package, this should be similar to what was searched if it wasn't an exact package name.
-2. `Tutorials` If there are any tutorials available in the documentation they will show up here. Those looking to get started with a package should look here as the tutorials will often be up to date and well maintained by those who use the package often.
 3. `Documentation` The original documentation for the ROS package and the repository where source code and documentation can be found.
 4. `Distribution` ROS 2 has [various distributions](https://docs.ros.org/en/rolling/Releases.html) which may have differences in design. Click on the ROS distribution (version) that matches the ROS version installed on your system.
 5. `Contributing` This software is open source, so it needs the community's help to actively be maintained. One should utilize this section if they wish to help solve issues, review pull requests, or are looking to see if an active fix is being deployed for a problem they encountered.


### PR DESCRIPTION
Remove the unused tutorial tab and all references to it as it remains unimplemeted and has no source of data. 

It would be great to formalize this and add it back but we don't need to keep generating it and useing up bandwidth and realestate. 