### PR TITLE
Eliminate CLS when rendering footer

### DIFF
--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -182,6 +182,7 @@
  */
 .page-content {
     padding: 0 0 0 0;
+    min-height: 100vh; // Make sure that the main window is larger than one page to avoid CLS when the footer renders before the main content and then gets pushed down. 
 }
 
 .page-heading {


### PR DESCRIPTION
This is a bit of a hack to push the footer down below the viewport in the first render pass. There are likely more elegant solutions, but as far as I can tell all of our content is longer than one viewport size so this won't have an effect on users. The worst case is that there's a little bit of extra whitespace and you have to scroll to see the footer.

This is the one primary CLS issue I can find, my local fixes from 0.10 to 0.00 in the chrome performance analysis.

Fixes #315
