### PR TITLE
This javascript reference was dropped by accident

### DIFF
--- a/_layouts/repo_instance.html
+++ b/_layouts/repo_instance.html
@@ -145,6 +145,6 @@ layout: default
   });
   $(document).ready(function() {
     setupDistroSwitch("{{ page.default_distro }}");
-    setupContributeLists("{{ page.repo.uri }}");
+    setupContributeLists("{{ repo.uri }}");
   });
 </script>


### PR DESCRIPTION
In the #580 refactor

@rkent if you can verify

Example: https://index.ros.org/r/ackermann_msgs/#humble

Before

<img width="550" height="182" alt="image" src="https://github.com/user-attachments/assets/dd2b5199-f66b-4610-aea3-50835506382c" />


After

<img width="608" height="200" alt="image" src="https://github.com/user-attachments/assets/1576b00e-2ce2-4f0d-8060-d7c2d966833b" />
