### PR TITLE
Add kilted as active distribution to welcome page.

### DIFF
--- a/_layouts/search_packages.html
+++ b/_layouts/search_packages.html
@@ -75,6 +75,9 @@ layout: default
       <p>
         <a href="https://docs.ros.org/en/jazzy/Releases/Release-Jazzy-Jalisco.html">ROS 2 Jazzy</a>
       </p>
+      <p>
+        <a href="https://docs.ros.org/en/jazzy/Releases/Release-Kilted-Kaiju.html">ROS 2 Kilted</a>
+      </p>
       <h2>Development Distribution</h2>
       <p>
         <a href="http://docs.ros.org/en/rolling/Releases/Release-Rolling-Ridley.html">ROS 2 Rolling</a>

--- a/_layouts/search_packages.html
+++ b/_layouts/search_packages.html
@@ -76,7 +76,7 @@ layout: default
         <a href="https://docs.ros.org/en/jazzy/Releases/Release-Jazzy-Jalisco.html">ROS 2 Jazzy</a>
       </p>
       <p>
-        <a href="https://docs.ros.org/en/jazzy/Releases/Release-Kilted-Kaiju.html">ROS 2 Kilted</a>
+        <a href="https://docs.ros.org/en/kilted/Releases/Release-Kilted-Kaiju.html">ROS 2 Kilted</a>
       </p>
       <h2>Development Distribution</h2>
       <p>


### PR DESCRIPTION
I just noticed the home page does not list kilted, so this adds it.