### PR TITLE
Support wildcards in rosdep

### DIFF
--- a/_plugins/rosindex_generator.rb
+++ b/_plugins/rosindex_generator.rb
@@ -117,6 +117,7 @@ def resolve_dep(ps, ms, os, ver, data)
   if data.is_a?(Hash)
     if data.key?(os) then return resolve_dep(ps, ms, os, ver, data[os]) end
     if data.key?(ver) then return resolve_dep(ps, ms, os, ver, data[ver]) end
+    if data.key?('*') then return resolve_dep(ps, ms, os, ver, data['*']) end
     if data.key?('source') and data['source'].key?('uri') then return data['source']['uri'] end
     if data.key?('packages') then return data['packages'] end
     ms.each do |manager_name, manager_oss|


### PR DESCRIPTION
Fixes #611

Generated-by: Portions of this commit may include code completion from github.copilot version 1.372.0 or later

It took me many hours to understand the rosdep parsing, but in the end the fix seems to be this simple one liner.

I've got a run available with this change at http://pr-rosindex.rosdabbler.com