### PR TITLE
Ignore packages with COLCON_IGNORE

### DIFF
--- a/_plugins/rosindex_generator.rb
+++ b/_plugins/rosindex_generator.rb
@@ -496,7 +496,7 @@ class Indexer < Jekyll::Generator
     Find.find(local_path) do |path|
       if FileTest.directory?(path)
         # skip certain paths
-        if (File.basename(path)[0] == ?.) or File.exist?(File.join(path,'CATKIN_IGNORE')) or File.exist?(File.join(path,'AMENT_IGNORE')) or File.exist?(File.join(path,'.rosindex_ignore'))
+        if (File.basename(path)[0] == ?.) or File.exist?(File.join(path,'CATKIN_IGNORE')) or File.exist?(File.join(path,'AMENT_IGNORE')) or File.exist?(File.join(path,'COLCON_IGNORE')) or File.exist?(File.join(path,'.rosindex_ignore'))
           Find.prune
         end
 


### PR DESCRIPTION
Should solve #624 .

I was always wondering which of AMENT_IGNORE or COLCON_IGNORE is the more proper one. But one can see both being used. So it makes sense that both are also ignored here.