### PR TITLE
link to message and service documentation

### DIFF
--- a/_includes/package_body.html
+++ b/_includes/package_body.html
@@ -328,7 +328,10 @@ Assumes distro and package are defined
         {% if n_msgs > 0 %}
           <ul>
             {% for f in package.data.msg_files %}
-              <li><a href="{{package.data.browse_uri}}/{{f}}" target="_blank">{{f}}</a></li>
+            {% assign msg_name = f | split: '/' | last | split: '.' | first %}
+            <li><a href="https://docs.ros.org/en/{{distro}}/p/{{package.name}}/msg/{{msg_name}}.html"
+                target="_blank"><strong>{{msg_name}}</strong></a> [<a href="{{package.data.browse_uri}}/{{f}}"
+                target="_blank">Source</a>]</li>
             {%endfor%}
           </ul>
         {% else %}
@@ -345,7 +348,10 @@ Assumes distro and package are defined
         {% if n_srvs > 0 %}
           <ul>
             {% for f in package.data.srv_files %}
-              <li><a href="{{package.data.browse_uri}}/{{f}}" target="_blank">{{f}}</a></li>
+            {% assign srv_name = f | split: '/' | last | split: '.' | first %}
+            <li><a href="https://docs.ros.org/en/{{distro}}/p/{{package.name}}/srv/{{srv_name}}.html"
+                target="_blank"><strong>{{srv_name}}</strong></a> [<a href="{{package.data.browse_uri}}/{{f}}"
+                target="_blank">Source</a>]</li>
             {%endfor%}
           </ul>
         {% else %}


### PR DESCRIPTION
It's a little awkward splitting the name out of the filename but works for now without refactoring the scraping


Example of it rendering
<img width="329" height="283" alt="image" src="https://github.com/user-attachments/assets/bfec18ab-2d88-469d-8bad-0f4675057a3a" />
